### PR TITLE
feat(lobby): friend invite statuses, debug logs, and host flow fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ addons/godotsteam/
 # Steam test app ID file — never commit
 steam_appid.txt
 
+# Local debug log output from run.ps1 -Mode debug
+logs/
+
 # OS clutter
 .DS_Store
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ Short version:
 
 The main menu includes a **Test (Offline)** button that skips Steam entirely and loads a local two-player session. Both sides are controlled by the same keyboard/mouse. Useful for testing game logic without a second machine.
 
+### Debug Logging (Steam/Lobby Issues)
+
+Use the project launcher in debug mode to auto-capture runtime errors:
+
+```powershell
+.\run.ps1 -Mode debug
+```
+
+This runs Godot with verbose console output and writes logs to:
+
+`logs/godot-debug-<timestamp>.log`
+
+Share the latest log file when host/join fails so issues can be diagnosed quickly.
+
 ---
 
 ## Tech Stack

--- a/project.godot
+++ b/project.godot
@@ -10,7 +10,7 @@ config_version=5
 config/name="BurnBridgers"
 config/description="Multiplayer 2D squad tactics — proof of concept"
 run/main_scene="res://scenes/main_menu.tscn"
-config/features=PackedStringArray("4.3", "GL Compatibility")
+config/features=PackedStringArray("4.6", "GL Compatibility")
 config/icon="res://icon.svg"
 
 [autoload]

--- a/run.ps1
+++ b/run.ps1
@@ -6,14 +6,18 @@
 .PARAMETER Mode
     editor  - Open the Godot editor with this project (default)
     offline - Open the editor and immediately run in offline test mode via --scene arg
+    debug   - Run via console binary and stream logs to file (best for multiplayer/Steam issues)
 
 .EXAMPLE
     .\run.ps1
     .\run.ps1 -Mode offline
+    .\run.ps1 -Mode debug
 #>
 param(
-    [ValidateSet("editor", "offline")]
-    [string]$Mode = "editor"
+    [ValidateSet("editor", "offline", "debug")]
+    [string]$Mode = "editor",
+    [switch]$NoLogCapture,
+    [switch]$NoLogWindow
 )
 
 $ProjectRoot = $PSScriptRoot
@@ -68,6 +72,13 @@ Then restart your terminal and try again.
 
 Write-Host "[BurnBridgers] Using Godot: $Godot" -ForegroundColor Cyan
 
+# Prefer console binary in debug mode so script errors are visible.
+$GodotConsole = $Godot -replace '\.exe$', '_console.exe'
+if ($Mode -eq "debug" -and -not (Test-Path $GodotConsole)) {
+    Write-Warning "[BurnBridgers] Console binary not found at: $GodotConsole. Falling back to standard executable."
+    $GodotConsole = $Godot
+}
+
 # ---------------------------------------------------------------------------
 # 2. Check required files
 # ---------------------------------------------------------------------------
@@ -94,6 +105,33 @@ if ($Mode -eq "offline") {
     # Pass a flag via a user arg so the game can read it (future) —
     # for now, editor opens normally; press Test (Offline) in the main menu.
     Write-Host "[BurnBridgers] Opening editor. Press 'Test (Offline)' in the main menu to skip Steam." -ForegroundColor Green
+}
+
+if ($Mode -eq "debug") {
+    $args += @("--verbose")
+    $logsDir = Join-Path $ProjectRoot "logs"
+    if (-not (Test-Path $logsDir)) {
+        New-Item -Path $logsDir -ItemType Directory | Out-Null
+    }
+    $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $logFile = Join-Path $logsDir "godot-debug-$timestamp.log"
+
+    Write-Host "[BurnBridgers] Launching debug mode with live logs..." -ForegroundColor Cyan
+    Write-Host "[BurnBridgers] Log file: $logFile" -ForegroundColor Yellow
+
+    if ($NoLogCapture) {
+        & $GodotConsole @args
+    } else {
+        if (-not $NoLogWindow) {
+            $tailCommand = "Get-Content -Path '$logFile' -Wait"
+            Start-Process powershell -ArgumentList @("-NoExit", "-Command", $tailCommand)
+            Write-Host "[BurnBridgers] Opened live log window." -ForegroundColor Green
+        }
+        # Tee both stdout/stderr so errors can be shared for debugging.
+        # Convert to plain text to avoid PowerShell NativeCommandError wrappers.
+        & $GodotConsole @args 2>&1 | ForEach-Object { $_.ToString() } | Tee-Object -FilePath $logFile
+    }
+    exit $LASTEXITCODE
 }
 
 Write-Host "[BurnBridgers] Launching... (mode: $Mode)" -ForegroundColor Cyan

--- a/scenes/lobby.tscn
+++ b/scenes/lobby.tscn
@@ -27,14 +27,36 @@ theme_override_constants/separation = 16
 text = "Lobby ID: ..."
 horizontal_alignment = 1
 
+[node name="LobbyStatusLabel" type="Label" parent="VBoxContainer"]
+text = "Lobby Members: 0/4"
+horizontal_alignment = 1
+
 [node name="PlayersTitle" type="Label" parent="VBoxContainer"]
 text = "Players:"
 
 [node name="PlayerList" type="VBoxContainer" parent="VBoxContainer"]
 theme_override_constants/separation = 4
 
+[node name="FriendsTitle" type="Label" parent="VBoxContainer"]
+text = "Invite Online Friends:"
+
+[node name="FriendsScroll" type="ScrollContainer" parent="VBoxContainer"]
+custom_minimum_size = Vector2(0, 120)
+
+[node name="FriendsList" type="VBoxContainer" parent="VBoxContainer/FriendsScroll"]
+size_flags_horizontal = 3
+theme_override_constants/separation = 6
+
+[node name="InviteNoteLabel" type="Label" parent="VBoxContainer"]
+text = "Note: Invites appear as Spacewar while using Steam App ID 480."
+autowrap_mode = 2
+
 [node name="StartButton" type="Button" parent="VBoxContainer"]
 text = "Start Match"
 visible = false
+
+[node name="RefreshTimer" type="Timer" parent="."]
+wait_time = 2.0
+autostart = false
 
 [connection signal="pressed" from="VBoxContainer/StartButton" to="." method="_on_start_button_pressed"]

--- a/scenes/main_menu.tscn
+++ b/scenes/main_menu.tscn
@@ -49,6 +49,32 @@ text = "Test (Offline)"
 [node name="ExitButton" type="Button" parent="VBoxContainer"]
 text = "Exit"
 
+[node name="DebugPanel" type="PanelContainer" parent="."]
+visible = false
+layout_mode = 1
+anchors_preset = 12
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 12.0
+offset_top = -220.0
+offset_right = -12.0
+offset_bottom = -12.0
+
+[node name="MarginContainer" type="MarginContainer" parent="DebugPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 8
+theme_override_constants/margin_top = 8
+theme_override_constants/margin_right = 8
+theme_override_constants/margin_bottom = 8
+
+[node name="DebugLog" type="RichTextLabel" parent="DebugPanel/MarginContainer"]
+custom_minimum_size = Vector2(0, 180)
+layout_mode = 2
+bbcode_enabled = false
+fit_content = false
+scroll_active = true
+
 [connection signal="pressed" from="VBoxContainer/HostButton" to="." method="_on_host_button_pressed"]
 [connection signal="pressed" from="VBoxContainer/JoinButton" to="." method="_on_join_button_pressed"]
 [connection signal="pressed" from="VBoxContainer/ConfirmJoinButton" to="." method="_on_confirm_join_button_pressed"]

--- a/scripts/autoload/game_manager.gd
+++ b/scripts/autoload/game_manager.gd
@@ -46,7 +46,7 @@ func start_match() -> void:
 	if not multiplayer.is_server():
 		push_warning("[GameManager] start_match called on non-host — ignoring.")
 		return
-	if players.size() < 2:
+	if players.size() < 1:
 		push_warning("[GameManager] Not enough players to start (%d registered)." % players.size())
 		return
 

--- a/scripts/autoload/steam_manager.gd
+++ b/scripts/autoload/steam_manager.gd
@@ -7,6 +7,8 @@ signal lobby_created(lobby_id: int)
 signal lobby_joined(lobby_id: int)
 signal peer_connected(peer_id: int)
 signal peer_disconnected(peer_id: int)
+signal debug_message(message: String, is_error: bool)
+signal lobby_members_updated()
 
 # ---------------------------------------------------------------------------
 # State
@@ -15,76 +17,207 @@ var steam_id: int = 0
 var steam_username: String = ""
 var lobby_id: int = 0
 var is_host: bool = false
+var steam_ready: bool = false
+var _steam: Object = null
+var debug_history: Array[Dictionary] = []
+var invited_friend_ids: Dictionary = {}
+
+const _RESULT_OK: int = 1
+const _LOBBY_TYPE_PUBLIC: int = 2
+const _CHAT_ROOM_ENTER_RESPONSE_SUCCESS: int = 1
+const _FRIEND_FLAG_IMMEDIATE: int = 4
+const _PERSONA_STATE_OFFLINE: int = 0
 
 # ---------------------------------------------------------------------------
 # Lifecycle
 # ---------------------------------------------------------------------------
 func _ready() -> void:
-	var init_result: Dictionary = Steam.steamInit()
-	if init_result["status"] != Steam.STEAM_API_INIT_RESULT_OK:
-		push_error("[SteamManager] Steam failed to init: " + str(init_result["verbal"]))
-		get_tree().quit()
+	if not Engine.has_singleton("Steam"):
+		var extension_path := "res://addons/godotsteam/godotsteam.gdextension"
+		if FileAccess.file_exists(extension_path):
+			var load_status: int = GDExtensionManager.load_extension(extension_path)
+			_emit_debug("[SteamManager] Attempted to load GodotSteam extension. Status: %d" % load_status, false)
+		else:
+			_emit_debug("[SteamManager] GodotSteam extension file missing at %s" % extension_path, true)
+			return
+	if not Engine.has_singleton("Steam"):
+		_emit_debug("[SteamManager] Steam singleton not available after loading extension. Check GodotSteam/Godot version compatibility.", true)
 		return
 
-	steam_id = Steam.getSteamID()
-	steam_username = Steam.getPersonaName()
-	print("[SteamManager] Initialized. User: %s (%d)" % [steam_username, steam_id])
+	_steam = Engine.get_singleton("Steam")
+	var init_response: Variant = _steam.call("steamInit")
+	var status: int = -1
+	var verbal: String = ""
+	var init_ok: bool = false
+	if init_response is Dictionary:
+		var init_result: Dictionary = init_response
+		status = int(init_result.get("status", -1))
+		verbal = str(init_result.get("verbal", ""))
+		# GodotSteam status enums vary slightly by version; accept known OK values + verbal fallback.
+		init_ok = status == 0 or status == 1 or verbal.to_upper().find("OK") != -1
+	elif init_response is bool:
+		init_ok = bool(init_response)
+		status = 1 if init_ok else 0
+		verbal = "steamInit() bool response"
+	else:
+		verbal = "Unexpected steamInit() response type: %s" % [typeof(init_response)]
+	if not init_ok:
+		_emit_debug("[SteamManager] Steam failed to init: " + verbal + " (status=" + str(status) + ")", true)
+		return
+
+	steam_id = int(_steam.call("getSteamID"))
+	steam_username = str(_steam.call("getPersonaName"))
+	steam_ready = true
+	_emit_debug("[SteamManager] Initialized. User: %s (%d)" % [steam_username, steam_id], false)
 
 	# Connect Steamworks signals
-	Steam.lobby_created.connect(_on_steam_lobby_created)
-	Steam.lobby_joined.connect(_on_steam_lobby_joined)
-	Steam.lobby_chat_update.connect(_on_lobby_chat_update)
+	_steam.connect("lobby_created", Callable(self, "_on_steam_lobby_created"))
+	_steam.connect("lobby_joined", Callable(self, "_on_steam_lobby_joined"))
+	_steam.connect("lobby_chat_update", Callable(self, "_on_lobby_chat_update"))
 
 func _process(_delta: float) -> void:
 	# Must be called every frame to dispatch Steam callbacks
-	Steam.run_callbacks()
+	if steam_ready and _steam != null:
+		_steam.call("run_callbacks")
 
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 func host_lobby() -> void:
+	if not steam_ready:
+		_emit_debug("[SteamManager] Cannot host lobby: Steam is not initialized.", true)
+		return
+
+	# Reset existing state so repeated Host attempts are reliable.
+	if lobby_id != 0:
+		_steam.call("leaveLobby", lobby_id)
+		lobby_id = 0
+	if multiplayer.multiplayer_peer != null:
+		multiplayer.multiplayer_peer.close()
+		multiplayer.multiplayer_peer = null
+
 	is_host = true
+	_emit_debug("[SteamManager] Creating lobby...", false)
 	# LOBBY_TYPE_PUBLIC so others can find it; max 4 players per spec
-	Steam.createLobby(Steam.LOBBY_TYPE_PUBLIC, 4)
+	_steam.call("createLobby", _LOBBY_TYPE_PUBLIC, 4)
 
 func join_lobby(target_lobby_id: int) -> void:
+	if not steam_ready:
+		_emit_debug("[SteamManager] Cannot join lobby: Steam is not initialized.", true)
+		return
+
 	is_host = false
-	Steam.joinLobby(target_lobby_id)
+	_emit_debug("[SteamManager] Joining lobby %d..." % target_lobby_id, false)
+	_steam.call("joinLobby", target_lobby_id)
+
+func get_lobby_member_names() -> Array[String]:
+	var members: Array[String] = []
+	if not steam_ready or _steam == null or lobby_id == 0:
+		return members
+	var member_count: int = int(_steam.call("getNumLobbyMembers", lobby_id))
+	for i in range(member_count):
+		var member_steam_id: int = int(_steam.call("getLobbyMemberByIndex", lobby_id, i))
+		members.append(str(_steam.call("getFriendPersonaName", member_steam_id)))
+	return members
+
+func get_lobby_member_ids() -> Array[int]:
+	var members: Array[int] = []
+	if not steam_ready or _steam == null or lobby_id == 0:
+		return members
+	var member_count: int = int(_steam.call("getNumLobbyMembers", lobby_id))
+	for i in range(member_count):
+		var member_steam_id: int = int(_steam.call("getLobbyMemberByIndex", lobby_id, i))
+		members.append(member_steam_id)
+	return members
+
+func get_online_friends() -> Array[Dictionary]:
+	var friends: Array[Dictionary] = []
+	if not steam_ready or _steam == null:
+		return friends
+	var friend_count: int = int(_steam.call("getFriendCount", _FRIEND_FLAG_IMMEDIATE))
+	for i in range(friend_count):
+		var friend_steam_id: int = int(_steam.call("getFriendByIndex", i, _FRIEND_FLAG_IMMEDIATE))
+		if friend_steam_id == 0 or friend_steam_id == steam_id:
+			continue
+		var persona_state: int = int(_steam.call("getFriendPersonaState", friend_steam_id))
+		if persona_state <= _PERSONA_STATE_OFFLINE:
+			continue
+		friends.append({
+			"steam_id": friend_steam_id,
+			"name": str(_steam.call("getFriendPersonaName", friend_steam_id)),
+			"state": persona_state
+		})
+	return friends
+
+func invite_friend_to_lobby(friend_steam_id: int) -> bool:
+	if not steam_ready or _steam == null:
+		_emit_debug("[SteamManager] Cannot invite: Steam is not initialized.", true)
+		return false
+	if not is_host or lobby_id == 0:
+		_emit_debug("[SteamManager] Cannot invite: no active host lobby.", true)
+		return false
+	var ok: bool = bool(_steam.call("inviteUserToLobby", lobby_id, friend_steam_id))
+	if ok:
+		invited_friend_ids[friend_steam_id] = Time.get_unix_time_from_system()
+		_emit_debug("[SteamManager] Invite sent to Steam ID %d." % friend_steam_id, false)
+	else:
+		_emit_debug("[SteamManager] Failed to invite Steam ID %d." % friend_steam_id, true)
+	return ok
+
+func get_friend_status(friend_steam_id: int) -> String:
+	var member_ids: Array[int] = get_lobby_member_ids()
+	if member_ids.has(friend_steam_id):
+		return "In Lobby"
+	if invited_friend_ids.has(friend_steam_id):
+		return "Invited"
+	return "Online"
 
 # ---------------------------------------------------------------------------
 # Steam callbacks
 # ---------------------------------------------------------------------------
 func _on_steam_lobby_created(result: int, new_lobby_id: int) -> void:
-	if result == 1:
+	if result == _RESULT_OK:
 		lobby_id = new_lobby_id
-		Steam.setLobbyData(lobby_id, "name", steam_username + "'s Lobby")
-		Steam.setLobbyData(lobby_id, "game", "BurnBridgers")
+		_steam.call("setLobbyData", lobby_id, "name", steam_username + "'s Lobby")
+		_steam.call("setLobbyData", lobby_id, "game", "BurnBridgers")
 		_setup_multiplayer_peer()
 		lobby_created.emit(lobby_id)
-		print("[SteamManager] Lobby created: %d" % lobby_id)
+		_emit_debug("[SteamManager] Lobby created: %d" % lobby_id, false)
 	else:
-		push_error("[SteamManager] Failed to create lobby. Result: " + str(result))
+		_emit_debug("[SteamManager] Failed to create lobby. Result: " + str(result), true)
 
 func _on_steam_lobby_joined(joined_lobby_id: int, _permissions: int, _locked: bool, response: int) -> void:
-	if response == Steam.CHAT_ROOM_ENTER_RESPONSE_SUCCESS:
+	if response == _CHAT_ROOM_ENTER_RESPONSE_SUCCESS:
+		# Hosts can receive a join callback for their own lobby after createLobby.
+		# Avoid re-creating the multiplayer peer in that case.
+		if is_host and joined_lobby_id == lobby_id and multiplayer.multiplayer_peer != null:
+			_emit_debug("[SteamManager] Host received self-join callback; peer already active.", false)
+			return
 		lobby_id = joined_lobby_id
 		_setup_multiplayer_peer()
 		lobby_joined.emit(lobby_id)
-		print("[SteamManager] Joined lobby: %d" % lobby_id)
+		_emit_debug("[SteamManager] Joined lobby: %d" % lobby_id, false)
 	else:
-		push_error("[SteamManager] Failed to join lobby. Response: " + str(response))
+		_emit_debug("[SteamManager] Failed to join lobby. Response: " + str(response), true)
 
 func _on_lobby_chat_update(_updated_lobby: int, changed_id: int, _making_change_id: int, _chat_state: int) -> void:
-	print("[SteamManager] Lobby member update for Steam ID: %d" % changed_id)
+	_emit_debug("[SteamManager] Lobby member update for Steam ID: %d" % changed_id, false)
+	lobby_members_updated.emit()
 
 # ---------------------------------------------------------------------------
 # Multiplayer peer setup
 # ---------------------------------------------------------------------------
 func _setup_multiplayer_peer() -> void:
-	var peer := SteamMultiplayerPeer.new()
+	if not ClassDB.class_exists("SteamMultiplayerPeer"):
+		_emit_debug("[SteamManager] SteamMultiplayerPeer class not found. Verify GodotSteam GDExtension install.", true)
+		return
+	var peer: MultiplayerPeer = ClassDB.instantiate("SteamMultiplayerPeer")
 
 	if is_host:
-		peer.create_host(0)
+		var host_result: int = int(peer.call("create_host", 0))
+		if host_result != OK:
+			_emit_debug("[SteamManager] Failed to create host peer. Error: %d" % host_result, true)
+			return
 		# Register host immediately — peer_id 1 is always the server
 		GameManager.players[1] = {
 			"steam_id": steam_id,
@@ -92,21 +225,37 @@ func _setup_multiplayer_peer() -> void:
 			"team": 0
 		}
 	else:
-		var host_steam_id: int = Steam.getLobbyOwner(lobby_id)
-		peer.create_client(host_steam_id, 0)
+		var host_steam_id: int = int(_steam.call("getLobbyOwner", lobby_id))
+		var client_result: int = int(peer.call("create_client", host_steam_id, 0))
+		if client_result != OK:
+			_emit_debug("[SteamManager] Failed to create client peer. Error: %d" % client_result, true)
+			return
 
 	multiplayer.multiplayer_peer = peer
-	multiplayer.peer_connected.connect(_on_peer_connected)
-	multiplayer.peer_disconnected.connect(_on_peer_disconnected)
-	print("[SteamManager] Multiplayer peer ready. is_host=%s" % str(is_host))
+	if not multiplayer.peer_connected.is_connected(_on_peer_connected):
+		multiplayer.peer_connected.connect(_on_peer_connected)
+	if not multiplayer.peer_disconnected.is_connected(_on_peer_disconnected):
+		multiplayer.peer_disconnected.connect(_on_peer_disconnected)
+	_emit_debug("[SteamManager] Multiplayer peer ready. is_host=%s" % str(is_host), false)
 
 func _on_peer_connected(peer_id: int) -> void:
-	print("[SteamManager] Peer connected: %d" % peer_id)
+	_emit_debug("[SteamManager] Peer connected: %d" % peer_id, false)
 	peer_connected.emit(peer_id)
 	# Clients register themselves with the host when connection is established
 	if not is_host:
 		GameManager.register_player_rpc.rpc_id(1, steam_id, steam_username)
 
 func _on_peer_disconnected(peer_id: int) -> void:
-	print("[SteamManager] Peer disconnected: %d" % peer_id)
+	_emit_debug("[SteamManager] Peer disconnected: %d" % peer_id, false)
 	peer_disconnected.emit(peer_id)
+
+func _emit_debug(message: String, is_error: bool) -> void:
+	debug_history.append({
+		"message": message,
+		"is_error": is_error
+	})
+	if is_error:
+		push_error(message)
+	else:
+		print(message)
+	debug_message.emit(message, is_error)

--- a/scripts/lobby.gd
+++ b/scripts/lobby.gd
@@ -4,8 +4,13 @@ extends Control
 # Node references
 # ---------------------------------------------------------------------------
 @onready var lobby_id_label: Label = $VBoxContainer/LobbyIdLabel
+@onready var lobby_status_label: Label = $VBoxContainer/LobbyStatusLabel
 @onready var player_list: VBoxContainer = $VBoxContainer/PlayerList
+@onready var friends_title: Label = $VBoxContainer/FriendsTitle
+@onready var friends_list: VBoxContainer = $VBoxContainer/FriendsScroll/FriendsList
+@onready var invite_note_label: Label = $VBoxContainer/InviteNoteLabel
 @onready var start_button: Button = $VBoxContainer/StartButton
+@onready var refresh_timer: Timer = $RefreshTimer
 
 # ---------------------------------------------------------------------------
 # Lifecycle
@@ -20,8 +25,13 @@ func _ready() -> void:
 	# Refresh list when peers connect/disconnect
 	SteamManager.peer_connected.connect(_refresh_player_list)
 	SteamManager.peer_disconnected.connect(_refresh_player_list)
+	SteamManager.lobby_members_updated.connect(_refresh_player_list.bind(0))
+
+	refresh_timer.timeout.connect(_on_refresh_timer_timeout)
+	refresh_timer.start()
 
 	_refresh_player_list(0)
+	_refresh_online_friends()
 
 # ---------------------------------------------------------------------------
 # Player list
@@ -34,18 +44,74 @@ func _refresh_player_list(_peer_id: int) -> void:
 	if SteamManager.lobby_id == 0:
 		return
 
-	var member_count: int = Steam.getNumLobbyMembers(SteamManager.lobby_id)
-	for i in range(member_count):
-		var member_steam_id: int = Steam.getLobbyMemberByIndex(SteamManager.lobby_id, i)
+	var members: Array[String] = SteamManager.get_lobby_member_names()
+	var member_count: int = members.size()
+	for member_name in members:
 		var label := Label.new()
-		label.text = Steam.getFriendPersonaName(member_steam_id)
+		label.text = member_name + " (In Lobby)"
 		player_list.add_child(label)
+	lobby_status_label.text = "Lobby Members: %d/4" % member_count
 
-	# Host can only start with at least 2 players
-	start_button.disabled = member_count < 2
+	# Host can start with any non-zero lobby size.
+	start_button.disabled = member_count < 1
+	_refresh_online_friends()
+
+func _refresh_online_friends() -> void:
+	for child in friends_list.get_children():
+		child.queue_free()
+
+	var host_can_invite: bool = SteamManager.is_host and SteamManager.steam_ready
+	friends_title.visible = host_can_invite
+	friends_list.get_parent().visible = host_can_invite
+	invite_note_label.visible = host_can_invite
+	if not host_can_invite:
+		return
+
+	var online_friends: Array[Dictionary] = SteamManager.get_online_friends()
+	if online_friends.is_empty():
+		var empty_label := Label.new()
+		empty_label.text = "No online Steam friends available to invite."
+		friends_list.add_child(empty_label)
+		return
+
+	for friend in online_friends:
+		var row := HBoxContainer.new()
+		row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+		var name_label := Label.new()
+		name_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		name_label.text = str(friend.get("name", "Unknown"))
+		row.add_child(name_label)
+
+		var status_label := Label.new()
+		var friend_id: int = int(friend.get("steam_id", 0))
+		var friend_status := SteamManager.get_friend_status(friend_id)
+		status_label.text = friend_status
+		status_label.custom_minimum_size = Vector2(80, 0)
+		row.add_child(status_label)
+
+		var invite_button := Button.new()
+		invite_button.text = "Invite"
+		invite_button.disabled = friend_status != "Online"
+		if friend_status == "Invited":
+			invite_button.text = "Invited"
+		elif friend_status == "In Lobby":
+			invite_button.text = "Joined"
+		invite_button.pressed.connect(_on_invite_friend_pressed.bind(friend_id))
+		row.add_child(invite_button)
+
+		friends_list.add_child(row)
 
 # ---------------------------------------------------------------------------
 # Button handlers
 # ---------------------------------------------------------------------------
 func _on_start_button_pressed() -> void:
 	GameManager.start_match()
+
+func _on_invite_friend_pressed(friend_steam_id: int) -> void:
+	if friend_steam_id > 0:
+		SteamManager.invite_friend_to_lobby(friend_steam_id)
+	_refresh_online_friends()
+
+func _on_refresh_timer_timeout() -> void:
+	_refresh_player_list(0)

--- a/scripts/main_menu.gd
+++ b/scripts/main_menu.gd
@@ -5,21 +5,52 @@ extends Control
 # ---------------------------------------------------------------------------
 @onready var join_input: LineEdit = $VBoxContainer/JoinLobbyIdInput
 @onready var confirm_join_button: Button = $VBoxContainer/ConfirmJoinButton
+@onready var host_button: Button = $VBoxContainer/HostButton
+@onready var debug_panel: PanelContainer = $DebugPanel
+@onready var debug_log: RichTextLabel = $DebugPanel/MarginContainer/DebugLog
 
 # ---------------------------------------------------------------------------
 # Lifecycle
 # ---------------------------------------------------------------------------
 func _ready() -> void:
-	SteamManager.lobby_created.connect(_on_lobby_ready)
-	SteamManager.lobby_joined.connect(_on_lobby_ready)
+	if SteamManager == null:
+		push_error("[MainMenu] SteamManager autoload missing.")
+	else:
+		SteamManager.lobby_created.connect(_on_lobby_ready)
+		SteamManager.lobby_joined.connect(_on_lobby_ready)
+		SteamManager.debug_message.connect(_on_steam_debug_message)
 	join_input.visible = false
 	confirm_join_button.visible = false
+
+	# Keep console visible for active debugging.
+	debug_panel.visible = true
+	_append_debug("[MainMenu] Debug console enabled.")
+	if SteamManager == null:
+		_append_debug("[MainMenu] SteamManager autoload missing.", true)
+	else:
+		for entry in SteamManager.debug_history:
+			_append_debug(str(entry.get("message", "")), bool(entry.get("is_error", false)))
+		host_button.disabled = not SteamManager.steam_ready
+		if host_button.disabled:
+			host_button.tooltip_text = "Steam is not initialized. Check debug console output."
+
+func _exit_tree() -> void:
+	if SteamManager == null:
+		return
+	if SteamManager.lobby_created.is_connected(_on_lobby_ready):
+		SteamManager.lobby_created.disconnect(_on_lobby_ready)
+	if SteamManager.lobby_joined.is_connected(_on_lobby_ready):
+		SteamManager.lobby_joined.disconnect(_on_lobby_ready)
+	if SteamManager.debug_message.is_connected(_on_steam_debug_message):
+		SteamManager.debug_message.disconnect(_on_steam_debug_message)
 
 # ---------------------------------------------------------------------------
 # Button handlers
 # ---------------------------------------------------------------------------
 func _on_host_button_pressed() -> void:
-	SteamManager.host_lobby()
+	_append_debug("[MainMenu] Host button pressed.")
+	if SteamManager != null:
+		SteamManager.host_lobby()
 
 func _on_join_button_pressed() -> void:
 	join_input.visible = true
@@ -29,9 +60,11 @@ func _on_join_button_pressed() -> void:
 func _on_confirm_join_button_pressed() -> void:
 	var lobby_id: int = int(join_input.text.strip_edges())
 	if lobby_id > 0:
-		SteamManager.join_lobby(lobby_id)
+		_append_debug("[MainMenu] Attempting join for lobby %d." % lobby_id)
+		if SteamManager != null:
+			SteamManager.join_lobby(lobby_id)
 	else:
-		push_warning("[MainMenu] Invalid lobby ID entered.")
+		_append_debug("[MainMenu] Invalid lobby ID entered.", true)
 
 func _on_test_button_pressed() -> void:
 	GameManager.setup_offline_test()
@@ -45,3 +78,13 @@ func _on_exit_button_pressed() -> void:
 # ---------------------------------------------------------------------------
 func _on_lobby_ready(_lobby_id: int) -> void:
 	get_tree().change_scene_to_file("res://scenes/lobby.tscn")
+
+func _on_steam_debug_message(message: String, is_error: bool) -> void:
+	_append_debug(message, is_error)
+
+func _append_debug(message: String, is_error: bool = false) -> void:
+	if not debug_panel.visible:
+		return
+	var prefix: String = "[ERR] " if is_error else "[LOG] "
+	debug_log.append_text(prefix + message + "\n")
+	debug_log.scroll_to_line(debug_log.get_line_count())


### PR DESCRIPTION
## Summary
- Add lobby-side online friend invite controls with live statuses (`Online`, `Invited`, `In Lobby`) and member count/status UI.
- Improve Steam startup reliability by loading GodotSteam extension when needed and handling `steamInit` return variations safely.
- Add stronger debug workflow: always-visible main-menu debug console, debug log history replay, and `run.ps1 -Mode debug` live log capture window.
- Allow host to start match with any non-zero player count.

## Test plan
- [x] Launch via `./run.ps1 -Mode debug` and verify logs are written and tailed
- [x] Host lobby and verify no duplicate peer/self-join callback errors
- [x] Verify lobby shows member status and invite button state transitions
- [x] Confirm match can start with single host in lobby