### PR TITLE
fix(steam): harden Steam Deck init and restore branch/PR automation p…

### DIFF
--- a/.cursor/rules/adr-governed-development.mdc
+++ b/.cursor/rules/adr-governed-development.mdc
@@ -194,10 +194,10 @@ Short-lived branches:
 Rules:
 
 1. No direct commits to `main`
-2. No direct commits to `develop` except controlled integration merges
-3. Every material change happens in short-lived branches
-4. Architecture-sensitive changes should include ADR changes in the same branch when possible
-5. If architecture needs discussion first, open an `adr/*` branch and merge ADR before implementation
+2. Every material change happens in short-lived branches created from `main`
+3. Architecture-sensitive changes should include ADR changes in the same branch when possible
+4. If architecture needs discussion first, open an `adr/*` branch and merge ADR before implementation
+5. After pushing a short-lived branch, immediately open a PR to `main` unless explicitly instructed not to
 6. PR body must satisfy required metadata fields and include ADR references/classification
 
 Branch intent:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,5 +9,7 @@ For non-trivial work:
 3. Classify request type (A/B/C/D from `AGENTS.md`).
 4. If new/superseding ADR is required, draft ADR before architecture-sensitive implementation.
 5. Include architecture compliance notes in summaries/reviews.
+6. Create a short-lived branch from `main` before implementing material changes.
+7. After pushing that branch, immediately create a PR targeting `main` unless explicitly instructed not to.
 
 Never silently implement ADR-conflicting architecture changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,10 +96,13 @@ If yes to any, flag clearly and propose corrective action.
 
 ## Branching and PR Expectations
 
-- Use short-lived branches for material changes (`feature/*`, `fix/*`, `hotfix/*`, `adr/*`).
+- Default development flow starts from `main`.
+- Create a short-lived branch before making material changes (`feature/*`, `fix/*`, `hotfix/*`, `adr/*`).
 - Avoid direct commits to long-lived branches except controlled integration flows.
 - Architecture-sensitive changes should include ADR updates in same branch when practical.
 - If architecture requires discussion first, land ADR branch before broad implementation.
+- After pushing a short-lived branch, immediately create a PR unless explicitly instructed not to.
+- Default PR target is `main`.
 - PR creation must include required metadata from the PR template and ADR references/classification.
 
 Every PR should state:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@ Claude agents in this repository must follow `AGENTS.md` as the canonical policy
 3. Classify work as Type A/B/C/D (implementation-only, ADR-extension, ADR-required, ADR-conflicting).
 4. If Type C or D, draft ADR work first and do not silently modify architecture-sensitive code.
 5. Include architecture compliance notes in task/PR summaries.
+6. Create a short-lived branch from `main` before coding material changes.
+7. After pushing that branch, immediately open a PR to `main` unless explicitly told not to.
 
 ## If Instructions Conflict
 

--- a/scripts/autoload/steam_manager.gd
+++ b/scripts/autoload/steam_manager.gd
@@ -45,6 +45,12 @@ const _PERSONA_STATE_OFFLINE: int = 0
 const _AVATAR_MEDIUM: int = 2
 const _INVITE_TIMEOUT_SECONDS: int = 45
 const _INIT_RETRY_MS: int = 2500
+const _STEAM_EXTENSION_CANDIDATES: Array[String] = [
+	"res://addons/godotsteam/godotsteam.gdextension",
+	"res://addons/GodotSteam/godotsteam.gdextension",
+	"res://addons/godotsteam/GodotSteam.gdextension",
+	"res://addons/GodotSteam/GodotSteam.gdextension"
+]
 
 # ---------------------------------------------------------------------------
 # Lifecycle
@@ -454,15 +460,16 @@ func _try_initialize_steam() -> void:
 	_next_init_retry_at_ms = Time.get_ticks_msec() + _INIT_RETRY_MS
 
 	if not Engine.has_singleton("Steam"):
-		var extension_path := "res://addons/godotsteam/godotsteam.gdextension"
+		var extension_path: String = _find_steam_extension_path()
 		if FileAccess.file_exists(extension_path):
 			var load_status: int = GDExtensionManager.load_extension(extension_path)
-			_emit_debug("[SteamManager] Attempted to load GodotSteam extension. Status: %d" % load_status, false)
+			_emit_debug("[SteamManager] Attempted to load GodotSteam extension (%s). Status: %d" % [extension_path, load_status], false)
 		else:
-			_emit_debug("[SteamManager] GodotSteam extension file missing at %s" % extension_path, true)
+			_emit_debug("[SteamManager] GodotSteam extension file missing. Checked: %s" % ", ".join(_STEAM_EXTENSION_CANDIDATES), true)
 			return
 	if not Engine.has_singleton("Steam"):
 		_emit_debug("[SteamManager] Steam singleton not available after loading extension. Will retry.", true)
+		_emit_steam_environment_hints()
 		return
 
 	_steam = Engine.get_singleton("Steam")
@@ -484,6 +491,7 @@ func _try_initialize_steam() -> void:
 		verbal = "Unexpected steamInit() response type: %s" % [typeof(init_response)]
 	if not init_ok:
 		_emit_debug("[SteamManager] Steam failed to init: " + verbal + " (status=" + str(status) + "). Will retry.", true)
+		_emit_steam_environment_hints()
 		return
 
 	steam_id = int(_steam.call("getSteamID"))
@@ -519,3 +527,17 @@ func _try_initialize_steam() -> void:
 		join_lobby(queued_lobby_id)
 	# Refresh lobby browser data on successful init.
 	request_burnbridgers_lobby_list()
+
+func _find_steam_extension_path() -> String:
+	for candidate in _STEAM_EXTENSION_CANDIDATES:
+		if FileAccess.file_exists(candidate):
+			return candidate
+	# Fall back to canonical path for logs/errors.
+	return _STEAM_EXTENSION_CANDIDATES[0]
+
+func _emit_steam_environment_hints() -> void:
+	var steam_app_id: String = OS.get_environment("SteamAppId")
+	var steam_game_id: String = OS.get_environment("SteamGameId")
+	_emit_debug("[SteamManager] Env SteamAppId=%s SteamGameId=%s" % [steam_app_id, steam_game_id], true)
+	if OS.get_name() == "Linux":
+		_emit_debug("[SteamManager] Linux/Steam Deck hint: launch from Steam client OR ensure steam_appid.txt exists next to the game binary when launching outside Steam.", true)


### PR DESCRIPTION
…olicy

Improve Steam initialization diagnostics and extension path fallback for Linux/Steam Deck environments, and update cross-agent policy docs to require short-lived branches plus automatic PR creation after push.

Made-with: Cursor

## Problem
Describe what problem this PR solves.

## Architecture Impact
- Classification: `Type A` / `Type B` / `Type C` / `Type D`
- Affected boundaries/subsystems:
- Why this is ADR-compliant:

## Risks / Follow-ups
- Residual risk:
- Follow-up tasks:
