### PR TITLE
fix(lobby): defer scene transition to avoid crash during Steam callbacks

### DIFF
--- a/scripts/main_menu.gd
+++ b/scripts/main_menu.gd
@@ -85,6 +85,9 @@ func _on_exit_button_pressed() -> void:
 # Lobby ready callback
 # ---------------------------------------------------------------------------
 func _on_lobby_ready(_lobby_id: int) -> void:
+	call_deferred("_do_scene_change_lobby")
+
+func _do_scene_change_lobby() -> void:
 	get_tree().change_scene_to_file("res://scenes/lobby.tscn")
 
 func _on_invite_join_requested(target_lobby_id: int) -> void:


### PR DESCRIPTION
Calling change_scene_to_file from inside Steam's run_callbacks chain caused a native crash when the scene tree was modified mid-frame. Use call_deferred to safely transition to the lobby scene after callbacks finish.

## What Changed
- Summarize the key code and behavior changes in this PR.
- Note any user-visible UI/UX updates.
- List any follow-up changes that still need to be done (optional).
