### PR TITLE
fix(match): keep host and offline test on same scene

### DIFF
--- a/scripts/autoload/game_manager.gd
+++ b/scripts/autoload/game_manager.gd
@@ -6,6 +6,7 @@ extends Node
 # GAME_OVER is set when the match ends (currently only win/draw is handled via TurnManager signal).
 # TODO: assign GAME_OVER in _on_match_over handler once end-match UI flow is implemented.
 enum MatchPhase { LOBBY, IN_MATCH, GAME_OVER }
+const MATCH_SCENE_PATH: String = "res://scenes/game/fight_scene.tscn"
 
 # ---------------------------------------------------------------------------
 # State
@@ -58,11 +59,11 @@ func start_match() -> void:
 
 	match_phase = MatchPhase.IN_MATCH
 	print("[GameManager] Starting match with %d players." % players.size())
-	_load_tactical_map.rpc()
+	_load_match_scene.rpc()
 
 @rpc("authority", "call_local", "reliable")
-func _load_tactical_map() -> void:
-	get_tree().change_scene_to_file("res://scenes/game/tactical_map.tscn")
+func _load_match_scene() -> void:
+	get_tree().change_scene_to_file(MATCH_SCENE_PATH)
 
 # ---------------------------------------------------------------------------
 # Cleanup

--- a/scripts/main_menu.gd
+++ b/scripts/main_menu.gd
@@ -66,7 +66,7 @@ func _on_confirm_join_button_pressed() -> void:
 		DebugOverlay.log_message("[MainMenu] Invalid lobby ID entered.", true)
 
 func _on_test_button_pressed() -> void:
-	get_tree().change_scene_to_file("res://scenes/game/fight_scene.tscn")
+	get_tree().change_scene_to_file(GameManager.MATCH_SCENE_PATH)
 
 func _on_exit_button_pressed() -> void:
 	get_tree().quit()


### PR DESCRIPTION
## Summary
- add a single `GameManager.MATCH_SCENE_PATH` constant for match scene routing
- update host-start flow to load the shared match scene path instead of a separate hardcoded scene
- update `Test (Offline)` to use the same shared path to prevent flow drift

## Test plan
- [ ] From main menu, click `Test (Offline)` and confirm it opens the expected robot/fight scene
- [ ] Host a lobby, mark players ready, click `Start`, and confirm it opens the same scene as offline test
- [ ] Return to menu and repeat both paths once to confirm consistency

Made with [Cursor](https://cursor.com)