### PR TITLE
Fix multiple GDScript errors and warnings across core scripts

### DIFF
--- a/scripts/autoload/game_manager.gd
+++ b/scripts/autoload/game_manager.gd
@@ -33,10 +33,10 @@ func set_music_enabled(enabled: bool) -> void:
 	music_enabled_changed.emit(music_enabled)
 
 func _ensure_controller_ui_actions() -> void:
-	_ensure_joy_button_for_action("ui_up", _UI_DPAD_UP)
-	_ensure_joy_button_for_action("ui_down", _UI_DPAD_DOWN)
-	_ensure_joy_button_for_action("ui_left", _UI_DPAD_LEFT)
-	_ensure_joy_button_for_action("ui_right", _UI_DPAD_RIGHT)
+	_ensure_joy_button_for_action("ui_up", JOY_BUTTON_DPAD_UP)
+	_ensure_joy_button_for_action("ui_down", JOY_BUTTON_DPAD_DOWN)
+	_ensure_joy_button_for_action("ui_left", JOY_BUTTON_DPAD_LEFT)
+	_ensure_joy_button_for_action("ui_right", JOY_BUTTON_DPAD_RIGHT)
 	_ensure_joy_button_for_action("ui_accept", JOY_BUTTON_A)
 	_ensure_joy_button_for_action("ui_cancel", JOY_BUTTON_B)
 	_ensure_joy_motion_for_action("ui_left", JOY_AXIS_LEFT_X, -1.0)

--- a/scripts/bridge_drawer.gd
+++ b/scripts/bridge_drawer.gd
@@ -2,7 +2,7 @@ extends Node2D
 
 const TILE_W: float = 64.0
 const TILE_H: float = 32.0
-const TERRAIN_RENDERER_SCRIPT := preload("res://scripts/shared/iso_terrain_renderer.gd")
+const TERRAIN_RENDERER_SCRIPT: GDScript = preload("res://scripts/shared/iso_terrain_renderer.gd")
 
 var time: float = 0.0
 var map_offset: Vector2 = Vector2.ZERO

--- a/scripts/iso_arena.gd
+++ b/scripts/iso_arena.gd
@@ -218,7 +218,7 @@ func _ensure_key_for_action(action: String, keycode: Key) -> void:
 	key_event.keycode = keycode
 	InputMap.action_add_event(action, key_event)
 
-func _ensure_joy_button_for_action(action: String, button_index: JoyButton) -> void:
+func _ensure_joy_button_for_action(action: String, button_index: JoyButton, device: int = -1) -> void:
 	for event in InputMap.action_get_events(action):
 		if event is InputEventJoypadButton and event.button_index == button_index and event.device == device:
 			return
@@ -733,6 +733,7 @@ func _draw_hud(vp: Vector2) -> void:
 	for i in range(_players.size()):
 		var p: Dictionary = _players[i]
 		var col_idx: int = i % MAX_COLS
+		@warning_ignore("integer_division")
 		var row_idx: int = i / MAX_COLS
 		var bx := pad + col_idx * spacing
 		var by := pad + row_idx * row_stride

--- a/scripts/lobby.gd
+++ b/scripts/lobby.gd
@@ -258,9 +258,9 @@ func _leave_lobby_and_return_to_menu() -> void:
 	# Return to main menu
 	get_tree().change_scene_to_file(GameManager.MAIN_MENU_SCENE_PATH)
 
-func _create_avatar_rect(steam_id: int, size: int) -> TextureRect:
+func _create_avatar_rect(steam_id: int, avatar_size: int) -> TextureRect:
 	var avatar := TextureRect.new()
-	avatar.custom_minimum_size = Vector2(size, size)
+	avatar.custom_minimum_size = Vector2(avatar_size, avatar_size)
 	avatar.expand_mode = TextureRect.EXPAND_FIT_WIDTH_PROPORTIONAL
 	avatar.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
 	var texture: Texture2D = SteamManager.get_player_avatar_texture(steam_id)

--- a/scripts/main_menu.gd
+++ b/scripts/main_menu.gd
@@ -224,7 +224,8 @@ func _get_primary_pad_id() -> int:
 func _setup_controller_debug_line() -> void:
 	_controller_debug_label = Label.new()
 	_controller_debug_label.name = "ControllerDebugLine"
-	_controller_debug_label.layout_mode = 1
+	@warning_ignore("int_as_enum_without_cast", "int_as_enum_without_match")
+	_controller_debug_label.layout_mode = 1 # LayoutMode.LAYOUT_MODE_ANCHORS
 	_controller_debug_label.anchors_preset = 0
 	_controller_debug_label.offset_left = 12.0
 	_controller_debug_label.offset_top = 12.0

--- a/scripts/shared/iso_terrain_renderer.gd
+++ b/scripts/shared/iso_terrain_renderer.gd
@@ -27,11 +27,6 @@ var _elev_noise: FastNoiseLite = null
 var _warp_noise: FastNoiseLite = null
 
 func configure_seed(seed_val: int) -> void:
-	# Keep gameplay resilient when optional terrain art is missing.
-	if ResourceLoader.exists(_TERRAIN_TEX_PATH):
-		_terrain_tex = load(_TERRAIN_TEX_PATH) as Texture2D
-	else:
-		_terrain_tex = null
 	_elev_noise = FastNoiseLite.new()
 	_elev_noise.seed               = seed_val
 	_elev_noise.noise_type         = FastNoiseLite.TYPE_SIMPLEX_SMOOTH
@@ -118,9 +113,6 @@ func _ensure_chunk(cx: int, cy: int) -> void:
 			data[i * chunk_size + j] = t
 	_chunks[key] = data
 
-func get_tile_at(wx: float, wy: float) -> int:
-	return _get_tile(floori(wx), floori(wy))
-
 func _get_tile(tx: int, ty: int) -> int:
 	var cx: int = floori(float(tx) / chunk_size)
 	var cy: int = floori(float(ty) / chunk_size)
@@ -132,7 +124,7 @@ func _get_tile(tx: int, ty: int) -> int:
 
 func get_tile_at(wx: float, wy: float) -> int:
 	if _elev_noise == null:
-		return T_GRASS
+		return T_SAND
 	return _get_tile(floori(wx), floori(wy))
 
 func _draw_fallback_tiles(canvas: CanvasItem, origin: Vector2, viewport: Vector2, tile_w: float, tile_h: float) -> void:


### PR DESCRIPTION
- game_manager.gd: Replace undefined _UI_DPAD_* with correct JOY_BUTTON_DPAD_* constants
- bridge_drawer.gd: Explicitly type TERRAIN_RENDERER_SCRIPT as GDScript to fix type inference error
- iso_terrain_renderer.gd: Remove duplicate get_tile_at(), drop undefined _TERRAIN_TEX_PATH/_terrain_tex refs, replace T_GRASS with T_SAND
- iso_arena.gd: Add missing device parameter to _ensure_joy_button_for_action(), suppress integer_division warning
- lobby.gd: Rename parameter size -> avatar_size to avoid shadowing Control.size
- main_menu.gd: Fix layout_mode integer enum warning, fix LAYOUT_MODE_ANCHORS not found

## What Changed
- Summarize the key code and behavior changes in this PR.
- Note any user-visible UI/UX updates.
- List any follow-up changes that still need to be done (optional).
