### PR TITLE
Globe arena solar-system follow-up (Sun + camera modes)

### DIFF
--- a/scenes/globe/globe_arena.tscn
+++ b/scenes/globe/globe_arena.tscn
@@ -48,15 +48,10 @@ script = ExtResource("1_globe")
 [node name="WorldEnvironment" type="WorldEnvironment" parent="." unique_id=413666926]
 environment = SubResource("Environment_1")
 
-[node name="DirectionalLight3D" type="DirectionalLight3D" parent="." unique_id=476553977]
-transform = Transform3D(0, 0, -1, 0, 1, 0, 1, 0, 0, 0, 0, 0)
-light_color = Color(1, 0.95, 0.85, 1)
-light_energy = 1.2
-
 [node name="Camera3D" type="Camera3D" parent="." unique_id=1762861519]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 3)
 near = 0.01
-far = 100.0
+far = 200000.0
 
 [node name="GlobeRoot" type="Node3D" parent="." unique_id=735332995]
 

--- a/scripts/globe_arena.gd
+++ b/scripts/globe_arena.gd
@@ -7,23 +7,37 @@ extends Node3D
 @onready var _moon:       Node3D         = $Moon
 
 # ── Focus ─────────────────────────────────────────────────────────────────────
-enum Focus { EARTH, MOON }
+enum Focus { EARTH, MOON, SYSTEM, SOLAR }
 var _focus: Focus = Focus.EARTH
 
-const MOON_CAM_DIST_DEFAULT: float = 0.8
+const MOON_CAM_DIST_DEFAULT: float = 0.6
 const MOON_CAM_DIST_MIN:     float = 0.4
-const MOON_CAM_DIST_MAX:     float = 4.0
+const MOON_CAM_DIST_MAX:     float = 0.6
 var _moon_cam_dist:        float = MOON_CAM_DIST_DEFAULT
 var _moon_cam_dist_target: float = MOON_CAM_DIST_DEFAULT
 
+const SYSTEM_CAM_DIST_DEFAULT: float = 12.0
+const SYSTEM_CAM_DIST_MIN:     float = 6.0
+const SYSTEM_CAM_DIST_MAX:     float = 12
+# True isometric direction: equal parts right/up/back so orbital plane is clearly visible
+const SYSTEM_CAM_DIR: Vector3 = Vector3(1.0, 1.0, 1.0)
+var _system_cam_dist:        float = SYSTEM_CAM_DIST_DEFAULT
+var _system_cam_dist_target: float = SYSTEM_CAM_DIST_DEFAULT
+
+const SOLAR_CAM_DIST_DEFAULT: float = 40000.0
+const SOLAR_CAM_DIST_MIN:     float = 15000.0
+const SOLAR_CAM_DIST_MAX:     float = 100000.0
+var _solar_cam_dist:        float = SOLAR_CAM_DIST_DEFAULT
+var _solar_cam_dist_target: float = SOLAR_CAM_DIST_DEFAULT
+
 # ── Orbit camera ──────────────────────────────────────────────────────────────
-const CAM_DIST_MIN:      float = 1.2
-const CAM_DIST_MAX:      float = 10.0
+const CAM_DIST_MIN:      float = 1.1
+const CAM_DIST_MAX:      float = 2.0
 const ZOOM_STEP:         float = 0.1
 const ZOOM_SMOOTH:       float = 8.0
 const ELEVATION_LIMIT:   float = 85.0   # keep away from pole singularity
 
-const DEFAULT_CAM_DIST:  float = 3.0
+const DEFAULT_CAM_DIST:  float = 2.0
 const DEFAULT_AZIMUTH:   float = 0.0
 const DEFAULT_ELEVATION: float = 20.0   # slightly above equator
 
@@ -43,10 +57,18 @@ const TIME_SCALE_STEPS: Array = [
 	0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
 	10, 20, 30, 40, 50, 60, 70, 80, 90,
 	100, 200, 300, 400, 500, 600, 700, 800, 900,
-	1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000
+	1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000,
+	20000, 30000, 40000, 50000, 60000, 70000, 80000, 90000, 100000
 ]
 var   _sim_angle:       float = 0.0
 var   _time_scale:      float = 1.0
+
+# ── Solar orbit ────────────────────────────────────────────────────────────────
+# True-scale Sun distance (Earth radius = 1.0 → 23480 scene units).
+# One orbit = 365.25 days. Starts at PI so Earth begins at scene origin (0,0,0).
+const EARTH_ORBIT_DIST:    float = 23480.0
+const ORBITAL_DEG_PER_SEC: float = 360.0 / (365.25 * 86400.0)  # ≈ 0.0000114°/s
+var   _orbital_angle:      float = PI
 
 # ── Hex selection ─────────────────────────────────────────────────────────────
 var _hex_data:     Array = []   # Array of {c:Vector3, n:Array, p:PackedVector3Array}
@@ -72,17 +94,50 @@ func _ready() -> void:
 	_add_goldberg_overlay()
 	_setup_hex_highlight()
 	_add_focus_hud()
+	_add_sun()
 	_update_globe()
 	_update_camera(0.0)
 
 func _process(delta: float) -> void:
 	_sim_angle       += BASE_DEG_PER_SEC * _time_scale * delta
+	_orbital_angle   += deg_to_rad(ORBITAL_DEG_PER_SEC * _time_scale * delta)
 	_cam_dist         = lerpf(_cam_dist, _cam_dist_target, ZOOM_SMOOTH * delta)
 	_moon_cam_dist    = lerpf(_moon_cam_dist, _moon_cam_dist_target, ZOOM_SMOOTH * delta)
+	_system_cam_dist  = lerpf(_system_cam_dist, _system_cam_dist_target, ZOOM_SMOOTH * delta)
+	_solar_cam_dist   = lerpf(_solar_cam_dist, _solar_cam_dist_target, ZOOM_SMOOTH * delta)
 	_moon.time_scale  = _time_scale
+
+	var earth_pos            := _calc_earth_pos()
+	_globe_root.position      = earth_pos
+	_moon.position            = earth_pos
+
+	# SOLAR: bodies are sub-pixel at true scale so mesh sizes are boosted for visibility.
+	# SYSTEM: bodies stay at true scale (1.0/0.27); only orbital distance is compressed.
+	# This keeps gameplay geometry (hex tiles, collision) untouched in all views.
+	if _focus == Focus.SOLAR:
+		_globe_root.scale = Vector3.ONE * 80.0
+		_moon.scale       = Vector3.ONE
+		_moon.set_display_scale(20.0)
+	elif _focus == Focus.SYSTEM:
+		_globe_root.scale = Vector3.ONE
+		_moon.scale       = Vector3.ONE / 12.0   # compresses orbital distance only
+		_moon.set_display_scale(12.0)            # cancels node scale so mesh stays true size
+	else:
+		_globe_root.scale = Vector3.ONE
+		_moon.scale       = Vector3.ONE
+		_moon.set_display_scale(1.0)
 
 	_update_globe()
 	_update_camera(delta)
+
+
+func _calc_earth_pos() -> Vector3:
+	# Earth orbits the Sun at EARTH_ORBIT_DIST. Sun is at (EARTH_ORBIT_DIST, 0, 0).
+	return Vector3(
+		EARTH_ORBIT_DIST + EARTH_ORBIT_DIST * cos(_orbital_angle),
+		0.0,
+		EARTH_ORBIT_DIST * sin(_orbital_angle)
+	)
 
 # ── Reset view ────────────────────────────────────────────────────────────────
 func _reset_view() -> void:
@@ -98,13 +153,21 @@ func _unhandled_input(event: InputEvent) -> void:
 			MOUSE_BUTTON_WHEEL_UP:
 				if _focus == Focus.EARTH:
 					_cam_dist_target = clampf(_cam_dist_target - ZOOM_STEP, CAM_DIST_MIN, CAM_DIST_MAX)
-				else:
+				elif _focus == Focus.MOON:
 					_moon_cam_dist_target = clampf(_moon_cam_dist_target - ZOOM_STEP * 0.1, MOON_CAM_DIST_MIN, MOON_CAM_DIST_MAX)
+				elif _focus == Focus.SYSTEM:
+					_system_cam_dist_target = clampf(_system_cam_dist_target - ZOOM_STEP * 2.0, SYSTEM_CAM_DIST_MIN, SYSTEM_CAM_DIST_MAX)
+				else:
+					_solar_cam_dist_target = clampf(_solar_cam_dist_target - ZOOM_STEP * 20000.0, SOLAR_CAM_DIST_MIN, SOLAR_CAM_DIST_MAX)
 			MOUSE_BUTTON_WHEEL_DOWN:
 				if _focus == Focus.EARTH:
 					_cam_dist_target = clampf(_cam_dist_target + ZOOM_STEP, CAM_DIST_MIN, CAM_DIST_MAX)
-				else:
+				elif _focus == Focus.MOON:
 					_moon_cam_dist_target = clampf(_moon_cam_dist_target + ZOOM_STEP * 0.1, MOON_CAM_DIST_MIN, MOON_CAM_DIST_MAX)
+				elif _focus == Focus.SYSTEM:
+					_system_cam_dist_target = clampf(_system_cam_dist_target + ZOOM_STEP * 2.0, SYSTEM_CAM_DIST_MIN, SYSTEM_CAM_DIST_MAX)
+				else:
+					_solar_cam_dist_target = clampf(_solar_cam_dist_target + ZOOM_STEP * 20000.0, SOLAR_CAM_DIST_MIN, SOLAR_CAM_DIST_MAX)
 
 	elif event is InputEventKey:
 		var key := event as InputEventKey
@@ -131,21 +194,35 @@ func _unhandled_input(event: InputEvent) -> void:
 					else:
 						_moon.navigate(Vector2(0.0, -1.0), _camera.global_transform.basis.x, _camera.global_transform.basis.y)
 				KEY_EQUAL:  # + / =
-					if not key.echo:
-						_step_time_scale(1)
+					_step_time_scale(1)
 				KEY_MINUS:
-					if not key.echo:
-						_step_time_scale(-1)
+					_step_time_scale(-1)
 				KEY_1:
 					if not key.echo:
 						_focus = Focus.EARTH
 						_cam_dir = Vector3.ZERO
+						_time_scale = minf(_time_scale, _max_time_scale())
 						_update_focus_label()
+						_update_timescale_label()
 				KEY_2:
 					if not key.echo:
 						_focus = Focus.MOON
 						_cam_dir = Vector3.ZERO
+						_time_scale = minf(_time_scale, _max_time_scale())
 						_update_focus_label()
+						_update_timescale_label()
+				KEY_3:
+					if not key.echo:
+						_focus = Focus.SYSTEM
+						_time_scale = minf(_time_scale, _max_time_scale())
+						_update_focus_label()
+						_update_timescale_label()
+				KEY_4:
+					if not key.echo:
+						_focus = Focus.SOLAR
+						_time_scale = minf(_time_scale, _max_time_scale())
+						_update_focus_label()
+						_update_timescale_label()
 				KEY_R:
 					if not key.echo:
 						_reset_view()
@@ -157,13 +234,16 @@ func _update_globe() -> void:
 
 # ── Orbit camera ──────────────────────────────────────────────────────────────
 func _update_camera(delta: float) -> void:
-	if _focus == Focus.MOON:
-		_update_camera_moon(delta)
-	else:
-		_update_camera_earth(delta)
+	match _focus:
+		Focus.MOON:   _update_camera_moon(delta)
+		Focus.SYSTEM: _update_camera_system()
+		Focus.SOLAR:  _update_camera_solar()
+		_:            _update_camera_earth(delta)
 
 
 func _update_camera_earth(delta: float) -> void:
+	var earth_pos := _globe_root.global_position
+
 	if not _hex_data.is_empty():
 		var target := (_globe_root.global_transform.basis * (_hex_data[_selected_hex].c as Vector3)).normalized()
 		if _cam_dir.is_zero_approx():
@@ -177,8 +257,8 @@ func _update_camera_earth(delta: float) -> void:
 	var target_up := perp.normalized() if perp.length_squared() > 1e-4 else Vector3.FORWARD
 	_cam_up        = _cam_up.slerp(target_up, 1.0 - exp(-CAM_TRACK_SPEED * delta))
 
-	_camera.position = _cam_dir * _cam_dist
-	_camera.look_at(Vector3.ZERO, _cam_up)
+	_camera.position = earth_pos + _cam_dir * _cam_dist
+	_camera.look_at(earth_pos, _cam_up)
 
 
 func _update_camera_moon(delta: float) -> void:
@@ -195,6 +275,24 @@ func _update_camera_moon(delta: float) -> void:
 	_camera.look_at(moon_center, Vector3.UP)
 
 
+func _update_camera_system() -> void:
+	# Fixed isometric overview of the Earth-Moon system.
+	# Camera follows Earth so the system stays centred regardless of solar orbit.
+	# SYSTEM_CAM_DIR (1,1,1) gives true-isometric elevation (~35°) with the
+	# orbital plane (XZ) clearly visible from above-and-to-the-side.
+	var earth_pos := _globe_root.global_position
+	_camera.position = earth_pos + SYSTEM_CAM_DIR.normalized() * _system_cam_dist
+	_camera.look_at(earth_pos, Vector3.UP)
+
+
+func _update_camera_solar() -> void:
+	# Isometric overview of the full solar system — centred on the Sun.
+	# Same (1,1,1) direction as the system view so the orbital plane (XZ) reads clearly.
+	var sun_pos := Vector3(EARTH_ORBIT_DIST, 0.0, 0.0)
+	_camera.position = sun_pos + SYSTEM_CAM_DIR.normalized() * _solar_cam_dist
+	_camera.look_at(sun_pos, Vector3.UP)
+
+
 # ── Texture loading ────────────────────────────────────────────────────────────
 func _apply_globe_texture() -> void:
 	var tex := load("res://assets/maps/globe.png") as Texture2D
@@ -202,11 +300,9 @@ func _apply_globe_texture() -> void:
 		push_error("globe_arena: cannot load res://assets/maps/globe.png")
 		return
 	var mat := StandardMaterial3D.new()
+	mat.shading_mode   = BaseMaterial3D.SHADING_MODE_UNSHADED
 	mat.albedo_texture = tex
 	mat.texture_filter = BaseMaterial3D.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC
-	mat.roughness      = 0.85
-	mat.metallic       = 0.0
-	mat.specular_mode  = BaseMaterial3D.SPECULAR_DISABLED
 	_globe_mesh.material_override = mat
 
 # ── Atmosphere halo ────────────────────────────────────────────────────────────
@@ -423,15 +519,52 @@ func _add_focus_hud() -> void:
 func _update_focus_label() -> void:
 	if _focus_label == null:
 		return
-	_focus_label.text = "[1] Earth  |  2: Moon" if _focus == Focus.EARTH \
-					  else "1: Earth  |  [2] Moon"
+	match _focus:
+		Focus.EARTH:  _focus_label.text = "[1] Earth  |  2: Moon  |  3: System  |  4: Solar"
+		Focus.MOON:   _focus_label.text = "1: Earth  |  [2] Moon  |  3: System  |  4: Solar"
+		Focus.SYSTEM: _focus_label.text = "1: Earth  |  2: Moon  |  [3] System  |  4: Solar"
+		Focus.SOLAR:  _focus_label.text = "1: Earth  |  2: Moon  |  3: System  |  [4] Solar"
+
+
+func _add_sun() -> void:
+	const SUN_RADIUS: float = 109.3
+
+	var mat := StandardMaterial3D.new()
+	mat.shading_mode               = BaseMaterial3D.SHADING_MODE_UNSHADED
+	mat.albedo_color               = Color(1.0, 0.98, 0.85, 1.0)
+	mat.emission_enabled           = true
+	mat.emission                   = Color(1.0, 0.92, 0.60)
+	mat.emission_energy_multiplier = 3.0
+
+	var mesh := SphereMesh.new()
+	mesh.radius          = SUN_RADIUS
+	mesh.height          = SUN_RADIUS * 2.0
+	mesh.radial_segments = 32
+	mesh.rings           = 16
+
+	var node               := MeshInstance3D.new()
+	node.name              = "Sun"
+	node.mesh              = mesh
+	node.material_override = mat
+	node.position          = Vector3(EARTH_ORBIT_DIST, 0.0, 0.0)
+	add_child(node)
+
+
+func _max_time_scale() -> float:
+	match _focus:
+		Focus.EARTH:  return 1000.0
+		Focus.MOON:   return 10000.0
+		Focus.SYSTEM: return 100000.0
+		Focus.SOLAR:  return 1000000.0
+	return 1000.0
 
 
 func _step_time_scale(direction: int) -> void:
+	var max_ts := _max_time_scale()
 	var steps: Array = TIME_SCALE_STEPS
 	if direction > 0:
 		for v in steps:
-			if v > _time_scale + 0.001:
+			if v > _time_scale + 0.001 and v <= max_ts:
 				_time_scale = v
 				_update_timescale_label()
 				return

--- a/scripts/moon.gd
+++ b/scripts/moon.gd
@@ -16,7 +16,9 @@ extends Node3D
 @export var ejecta_ray:    Color = Color("#4A4A4A")
 
 # ── Constants ─────────────────────────────────────────────────────────────────
-const ORBIT_DIST:             float = 6.0
+const ORBIT_DIST:             float = 60.27  # 384,400 km / 6,371 km = 60.27 Earth radii
+# Orbital plane is tilted 5.14° from the ecliptic (XZ plane).
+const ORBITAL_INCLINATION_DEG: float = 5.14
 # At time_scale 1.0 = real-time: one orbit per 27.3 days = 27.3 × 86400 real seconds.
 const BASE_ORBIT_DEG_PER_SEC: float = 360.0 / (27.3 * 86400.0)  # ≈ 0.0001526°/s
 
@@ -43,13 +45,18 @@ func _ready() -> void:
 
 func _process(delta: float) -> void:
 	_orbit_angle += BASE_ORBIT_DEG_PER_SEC * orbit_speed * time_scale * delta
-	rotation_degrees.y = _orbit_angle   # pivot rotates → Moon orbits; tidal lock is automatic
+	# Combine orbital rotation (around Y) with the 5.14° ecliptic inclination (tilt around X).
+	# Multiplying incline * orbit applies the tilt to the whole orbital plane while
+	# preserving tidal lock — the Moon mesh at (ORBIT_DIST, 0, 0) still always faces Earth.
+	var orbit_q   := Quaternion(Vector3.UP,   deg_to_rad(_orbit_angle))
+	var incline_q := Quaternion(Vector3.RIGHT, deg_to_rad(ORBITAL_INCLINATION_DEG))
+	quaternion = incline_q * orbit_q
 
 	# Update Earthshine direction each frame
 	if _moon_mat != null and _moon_mesh != null:
 		var cam := get_viewport().get_camera_3d()
 		if cam != null:
-			var to_earth := (Vector3.ZERO - _moon_mesh.global_position).normalized()
+			var to_earth := (global_position - _moon_mesh.global_position).normalized()
 			var view_dir := cam.global_transform.basis.inverse() * to_earth
 			_moon_mat.set_shader_parameter("earth_dir_view", view_dir)
 
@@ -77,6 +84,7 @@ func _build_moon_mesh() -> void:
 func _build_surface_material() -> ShaderMaterial:
 	var shader_code := """
 shader_type spatial;
+render_mode unshaded;
 
 uniform sampler2D albedo_tex    : hint_default_white,  filter_linear_mipmap_anisotropic;
 uniform sampler2D displacement_tex : hint_default_black, filter_linear_mipmap_anisotropic;
@@ -288,6 +296,11 @@ func _update_hex_highlight() -> void:
 
 
 # ── Public API (called by globe_arena.gd) ─────────────────────────────────────
+func set_display_scale(s: float) -> void:
+	if _moon_mesh != null:
+		_moon_mesh.scale = Vector3.ONE * s
+
+
 func get_world_center() -> Vector3:
 	if _moon_mesh == null:
 		return Vector3.ZERO


### PR DESCRIPTION
## Summary
- Bring in the post-merge globe follow-up commit (`086c7cf`) as a focused change-set on top of `main`.
- Add visible Sun sphere/orbit context and expanded camera view modes in globe arena behavior.
- Keep scope intentionally narrow to `scenes/globe/globe_arena.tscn`, `scripts/globe_arena.gd`, and `scripts/moon.gd` (no loading-screen reintroduction).

## Test plan
- [ ] Launch project and open globe arena scene.
- [ ] Verify Sun is visible and positioned as expected in system view.
- [ ] Cycle camera/view modes and confirm transitions/focus targets are correct.
- [ ] Verify moon behavior still updates correctly under new camera/time controls.
- [ ] Smoke test return/navigation flow to ensure no regressions.

Made with [Cursor](https://cursor.com)