### PR TITLE
Automate Steam playtest pipeline and setup reliability fixes

### DIFF
--- a/.github/workflows/steam-playtest.yml
+++ b/.github/workflows/steam-playtest.yml
@@ -1,0 +1,49 @@
+name: Build And Upload Steam Playtest
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  export-and-upload:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    env:
+      GODOT_VERSION: "4.6.1"
+      EXPORT_PRESET_NAME: "Windows Desktop"
+      BUILD_OUTPUT_DIR: "build/windows"
+      STEAM_BRANCH: "playtest"
+      STEAM_APP_ID: ${{ secrets.STEAM_APP_ID }}
+      STEAM_DEPOT_ID_WINDOWS: ${{ secrets.STEAM_DEPOT_ID_WINDOWS }}
+      STEAM_BUILDER_USERNAME: ${{ secrets.STEAM_BUILDER_USERNAME }}
+      STEAM_BUILDER_PASSWORD: ${{ secrets.STEAM_BUILDER_PASSWORD }}
+      STEAM_GUARD_CODE: ${{ secrets.STEAM_GUARD_CODE }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Godot
+        uses: firebelley/setup-godot@v1
+        with:
+          godot-version: ${{ env.GODOT_VERSION }}
+          include-templates: true
+
+      - name: Export Windows build
+        shell: pwsh
+        run: |
+          ./tools/ci/export-windows.ps1 `
+            -ProjectRoot "$PWD" `
+            -ExportPresetName "${env:EXPORT_PRESET_NAME}" `
+            -OutputDir "${env:BUILD_OUTPUT_DIR}"
+
+      - name: Upload to Steam Playtest branch
+        shell: pwsh
+        run: |
+          ./tools/ci/upload-steam.ps1 `
+            -ProjectRoot "$PWD" `
+            -BuildOutputDir "${env:BUILD_OUTPUT_DIR}" `
+            -SteamBranch "${env:STEAM_BRANCH}"

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -234,14 +234,14 @@ if ($hasZivaBinary) {
         Write-Host "Skipped Ziva Agent."
         $installZiva = $false
     }
-} elseif (Test-Path $ZivaDir -PathType Container -and $Force) {
+} elseif ((Test-Path $ZivaDir -PathType Container) -and $Force) {
     Remove-Item -Recurse -Force $ZivaDir
 }
 
 if ($installZiva) {
     Write-Host "Installing Ziva Agent via official installer..."
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Invoke-Expression ((Invoke-WebRequest -UseBasicParsing -Uri "https://ziva.sh/install.ps1").Content)
+    irm https://ziva.sh/install.ps1 | iex
     $hasZivaBinary = (Test-Path $ZivaLibX64) -or (Test-Path $ZivaLibArm64)
     if (-not $hasZivaBinary) {
         Write-Error "Ziva install completed, but Windows binary was not found under $ZivaDir\bin."

--- a/tools/ci/export-windows.ps1
+++ b/tools/ci/export-windows.ps1
@@ -1,0 +1,33 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ProjectRoot,
+    [Parameter(Mandatory = $false)]
+    [string]$ExportPresetName = "Windows Desktop",
+    [Parameter(Mandatory = $false)]
+    [string]$OutputDir = "build/windows"
+)
+
+$ErrorActionPreference = "Stop"
+
+$projectRootResolved = (Resolve-Path $ProjectRoot).Path
+$outputDirResolved = Join-Path $projectRootResolved $OutputDir
+$presetTemplatePath = Join-Path $projectRootResolved "tools/ci/export_presets.ci.cfg"
+$presetPath = Join-Path $projectRootResolved "export_presets.cfg"
+
+if (-not (Test-Path $presetTemplatePath)) {
+    throw "Missing preset template at '$presetTemplatePath'."
+}
+
+Copy-Item -Path $presetTemplatePath -Destination $presetPath -Force
+New-Item -ItemType Directory -Path $outputDirResolved -Force | Out-Null
+
+$gameExePath = Join-Path $outputDirResolved "FireTeamMNG.exe"
+
+Write-Host "Exporting with preset '$ExportPresetName' to '$gameExePath'..."
+godot --headless --path $projectRootResolved --export-release $ExportPresetName $gameExePath
+
+if (-not (Test-Path $gameExePath)) {
+    throw "Export failed: expected executable '$gameExePath' was not created."
+}
+
+Write-Host "Export complete."

--- a/tools/ci/export_presets.ci.cfg
+++ b/tools/ci/export_presets.ci.cfg
@@ -1,0 +1,35 @@
+[preset.0]
+
+name="Windows Desktop"
+platform="Windows Desktop"
+runnable=true
+advanced_options=false
+dedicated_server=false
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="build/windows/FireTeamMNG.exe"
+patch_list=PackedStringArray()
+encryption_include_filters=""
+encryption_exclude_filters=""
+encrypt_pck=false
+encrypt_directory=false
+script_export_mode=1
+
+[preset.0.options]
+
+custom_template/debug=""
+custom_template/release=""
+debug/export_console_wrapper=1
+binary_format/embed_pck=false
+texture_format/s3tc_bptc=true
+texture_format/etc2_astc=false
+texture_format/no_bptc_fallbacks=true
+codesign/enable=false
+application/modify_resources=false
+application/icon=""
+application/console_wrapper_icon=""
+application/icon_interpolation=4
+architecture/x86_64=true
+architecture/x86_32=false

--- a/tools/ci/upload-steam.ps1
+++ b/tools/ci/upload-steam.ps1
@@ -1,0 +1,79 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ProjectRoot,
+    [Parameter(Mandatory = $false)]
+    [string]$BuildOutputDir = "build/windows",
+    [Parameter(Mandatory = $false)]
+    [string]$SteamBranch = "playtest"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Require-Env {
+    param([string]$Name)
+    $value = [Environment]::GetEnvironmentVariable($Name)
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        throw "Missing required environment variable: $Name"
+    }
+    return $value
+}
+
+$projectRootResolved = (Resolve-Path $ProjectRoot).Path
+$contentRoot = Join-Path $projectRootResolved $BuildOutputDir
+if (-not (Test-Path $contentRoot)) {
+    throw "Build output directory not found: '$contentRoot'"
+}
+
+$steamAppId = Require-Env "STEAM_APP_ID"
+$steamDepotIdWindows = Require-Env "STEAM_DEPOT_ID_WINDOWS"
+$steamUser = Require-Env "STEAM_BUILDER_USERNAME"
+$steamPassword = Require-Env "STEAM_BUILDER_PASSWORD"
+$steamGuardCode = [Environment]::GetEnvironmentVariable("STEAM_GUARD_CODE")
+
+$steamDir = Join-Path $env:RUNNER_TEMP "steamcmd"
+New-Item -ItemType Directory -Path $steamDir -Force | Out-Null
+$steamZip = Join-Path $steamDir "steamcmd.zip"
+$steamExe = Join-Path $steamDir "steamcmd.exe"
+
+if (-not (Test-Path $steamExe)) {
+    Write-Host "Downloading SteamCMD..."
+    Invoke-WebRequest -Uri "https://steamcdn-a.akamaihd.net/client/installer/steamcmd.zip" -OutFile $steamZip -UseBasicParsing
+    Expand-Archive -Path $steamZip -DestinationPath $steamDir -Force
+}
+
+$templateAppBuild = Join-Path $projectRootResolved "tools/steam/app_build_template.vdf"
+$templateDepotBuild = Join-Path $projectRootResolved "tools/steam/depot_build_windows_template.vdf"
+if (-not (Test-Path $templateAppBuild)) { throw "Missing $templateAppBuild" }
+if (-not (Test-Path $templateDepotBuild)) { throw "Missing $templateDepotBuild" }
+
+$generatedDir = Join-Path $env:RUNNER_TEMP "steam_build"
+New-Item -ItemType Directory -Path $generatedDir -Force | Out-Null
+$generatedAppBuild = Join-Path $generatedDir "app_build.vdf"
+$generatedDepotBuild = Join-Path $generatedDir "depot_build_windows.vdf"
+
+$description = "GitHub Actions build $($env:GITHUB_RUN_NUMBER) - $($env:GITHUB_SHA)"
+
+$appBuildText = Get-Content $templateAppBuild -Raw
+$appBuildText = $appBuildText.Replace("__APP_ID__", $steamAppId)
+$appBuildText = $appBuildText.Replace("__DESC__", $description)
+$appBuildText = $appBuildText.Replace("__SETLIVE__", $SteamBranch)
+$appBuildText = $appBuildText.Replace("__CONTENT_ROOT__", $contentRoot)
+$appBuildText = $appBuildText.Replace("__DEPOT_ID_WINDOWS__", $steamDepotIdWindows)
+Set-Content -Path $generatedAppBuild -Value $appBuildText -NoNewline
+
+$depotBuildText = Get-Content $templateDepotBuild -Raw
+$depotBuildText = $depotBuildText.Replace("__DEPOT_ID_WINDOWS__", $steamDepotIdWindows)
+Set-Content -Path $generatedDepotBuild -Value $depotBuildText -NoNewline
+
+Write-Host "Uploading build to Steam app $steamAppId (branch: $SteamBranch)..."
+if ([string]::IsNullOrWhiteSpace($steamGuardCode)) {
+    & $steamExe +login $steamUser $steamPassword +run_app_build $generatedAppBuild +quit
+} else {
+    & $steamExe +set_steam_guard_code $steamGuardCode +login $steamUser $steamPassword +run_app_build $generatedAppBuild +quit
+}
+
+if ($LASTEXITCODE -ne 0) {
+    throw "SteamCMD upload failed with exit code $LASTEXITCODE"
+}
+
+Write-Host "Steam upload complete."

--- a/tools/steam/README.md
+++ b/tools/steam/README.md
@@ -1,0 +1,29 @@
+# Steam Playtest CI/CD
+
+This repository includes a GitHub Actions workflow that exports a Windows build and uploads it to Steam whenever `main` is updated.
+
+## Workflow
+
+- File: `.github/workflows/steam-playtest.yml`
+- Trigger: push to `main` (and manual `workflow_dispatch`)
+- Steps:
+  - Export Godot Windows build (`tools/ci/export-windows.ps1`)
+  - Upload build to Steam (`tools/ci/upload-steam.ps1`)
+
+## Required GitHub Secrets
+
+Set these in **Repository Settings -> Secrets and variables -> Actions**:
+
+- `STEAM_APP_ID` (your playtest app ID)
+- `STEAM_DEPOT_ID_WINDOWS` (Windows depot ID in Steamworks)
+- `STEAM_BUILDER_USERNAME` (Steam build account username)
+- `STEAM_BUILDER_PASSWORD` (Steam build account password)
+- `STEAM_GUARD_CODE` (optional, only if your build account requires it)
+
+## Branch target
+
+By default, uploads set live to Steam branch:
+
+- `playtest`
+
+Change `STEAM_BRANCH` in `.github/workflows/steam-playtest.yml` if needed.

--- a/tools/steam/app_build_template.vdf
+++ b/tools/steam/app_build_template.vdf
@@ -1,0 +1,12 @@
+"appbuild"
+{
+	"appid" "__APP_ID__"
+	"desc" "__DESC__"
+	"buildoutput" "build_output"
+	"contentroot" "__CONTENT_ROOT__"
+	"setlive" "__SETLIVE__"
+	"depots"
+	{
+		"__DEPOT_ID_WINDOWS__" "depot_build_windows.vdf"
+	}
+}

--- a/tools/steam/depot_build_windows_template.vdf
+++ b/tools/steam/depot_build_windows_template.vdf
@@ -1,0 +1,13 @@
+"DepotBuildConfig"
+{
+	"DepotID" "__DEPOT_ID_WINDOWS__"
+	"ContentRoot" "."
+	"FileMapping"
+	{
+		"LocalPath" "*"
+		"DepotPath" "."
+		"recursive" "1"
+	}
+	"FileExclusion" "*.pdb"
+	"FileExclusion" "*.tmp"
+}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that exports a Windows build on pushes to `main` and uploads it to the Steam playtest branch using SteamPipe templates
- add CI scripts/templates for Godot export and Steam upload under `tools/ci` and `tools/steam`
- improve setup scripts for addon install reliability (skip reinstall by default, support force reinstall, and include Ziva install handling)

## Test plan
- [x] run `setup-windows.ps1 -NonInteractive` and verify it completes successfully
- [x] validate required addon binaries are present for GodotSteam and Ziva after setup
- [ ] run a GitHub Actions workflow dispatch with configured Steam secrets and verify Steam upload succeeds
- [ ] launch from Steam playtest app and verify lobby/invite flow works with App ID `4530870`