### PR TITLE
Fix workflow Godot setup action resolution

### DIFF
--- a/.github/workflows/steam-playtest.yml
+++ b/.github/workflows/steam-playtest.yml
@@ -27,9 +27,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Godot
-        uses: firebelley/setup-godot@v1
+        uses: chickensoft-games/setup-godot@v2
         with:
-          godot-version: ${{ env.GODOT_VERSION }}
+          version: ${{ env.GODOT_VERSION }}
           include-templates: true
 
       - name: Export Windows build


### PR DESCRIPTION
## Summary
- replace invalid `firebelley/setup-godot@v1` reference with `chickensoft-games/setup-godot@v2`
- update workflow input from `godot-version` to `version`
- restore `export-and-upload` pipeline startup so build/export/upload can run

## Test plan
- [x] validate workflow YAML diff targets only setup action wiring
- [ ] run workflow dispatch and verify `export-and-upload` resolves all actions