### PR TITLE
Fix CI Godot export robustness and lobby online friend filtering

### DIFF
--- a/.github/workflows/steam-playtest.yml
+++ b/.github/workflows/steam-playtest.yml
@@ -16,6 +16,7 @@ jobs:
       EXPORT_PRESET_NAME: "Windows Desktop"
       BUILD_OUTPUT_DIR: "build/windows"
       STEAM_BRANCH: "playtest"
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       STEAM_APP_ID: ${{ secrets.STEAM_APP_ID }}
       STEAM_DEPOT_ID_WINDOWS: ${{ secrets.STEAM_DEPOT_ID_WINDOWS }}
       STEAM_BUILDER_USERNAME: ${{ secrets.STEAM_BUILDER_USERNAME }}
@@ -24,13 +25,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Godot
         uses: chickensoft-games/setup-godot@v2
         with:
           version: ${{ env.GODOT_VERSION }}
           include-templates: true
+
+      - name: Verify Godot CLI
+        shell: pwsh
+        run: |
+          if ($env:GODOT4) { Write-Host "GODOT4=$env:GODOT4" }
+          if ($env:GODOT) { Write-Host "GODOT=$env:GODOT" }
+          try { godot --version } catch { Write-Host "godot command not in PATH" }
+          try { godot4 --version } catch { Write-Host "godot4 command not in PATH" }
 
       - name: Export Windows build
         shell: pwsh

--- a/scripts/screens/lobby.gd
+++ b/scripts/screens/lobby.gd
@@ -215,20 +215,14 @@ func _refresh_online_friends() -> void:
 		invite_note_label.text = "Invites appear as FireTeam MNG."
 
 	var online_friends: Array[Dictionary] = SteamManager.get_online_friends()
-	var in_game_friends: Array[Dictionary] = []
-	for friend in online_friends:
-		var friend_game_app_id: int = int(friend.get("game_app_id", 0))
-		if app_id > 0 and friend_game_app_id == app_id:
-			in_game_friends.append(friend)
-
-	if in_game_friends.is_empty():
+	if online_friends.is_empty():
 		var empty_label := Label.new()
-		empty_label.text = "No friends currently in FireTeam MNG."
+		empty_label.text = "No online friends available to invite."
 		UiStyleScript.style_body(empty_label, true)
 		friends_list.add_child(empty_label)
 		return
 
-	for friend in in_game_friends:
+	for friend in online_friends:
 		var row_panel := PanelContainer.new()
 		row_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 		UiStyleScript.style_panel(row_panel)

--- a/tools/ci/export-windows.ps1
+++ b/tools/ci/export-windows.ps1
@@ -9,6 +9,22 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+function Resolve-GodotCommand {
+    $candidates = @()
+    if (-not [string]::IsNullOrWhiteSpace($env:GODOT4)) { $candidates += $env:GODOT4 }
+    if (-not [string]::IsNullOrWhiteSpace($env:GODOT)) { $candidates += $env:GODOT }
+    $candidates += @("godot", "godot4")
+
+    foreach ($candidate in $candidates) {
+        if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
+        if (Test-Path $candidate) { return $candidate }
+        $command = Get-Command $candidate -ErrorAction SilentlyContinue
+        if ($null -ne $command) { return $command.Path }
+    }
+
+    throw "Godot CLI not found. Checked env:GODOT4, env:GODOT, godot, and godot4."
+}
+
 $projectRootResolved = (Resolve-Path $ProjectRoot).Path
 $outputDirResolved = Join-Path $projectRootResolved $OutputDir
 $presetTemplatePath = Join-Path $projectRootResolved "tools/ci/export_presets.ci.cfg"
@@ -22,12 +38,20 @@ Copy-Item -Path $presetTemplatePath -Destination $presetPath -Force
 New-Item -ItemType Directory -Path $outputDirResolved -Force | Out-Null
 
 $gameExePath = Join-Path $outputDirResolved "FireTeamMNG.exe"
+$godotCommand = Resolve-GodotCommand
 
 Write-Host "Exporting with preset '$ExportPresetName' to '$gameExePath'..."
-godot --headless --path $projectRootResolved --export-release $ExportPresetName $gameExePath
+Write-Host "Using Godot CLI: $godotCommand"
+& $godotCommand --headless --path $projectRootResolved --export-release $ExportPresetName $gameExePath
+
+if ($LASTEXITCODE -ne 0) {
+    throw "Godot export command failed with exit code $LASTEXITCODE."
+}
 
 if (-not (Test-Path $gameExePath)) {
-    throw "Export failed: expected executable '$gameExePath' was not created."
+    $dirListing = (Get-ChildItem -Path $outputDirResolved -File -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name) -join ", "
+    if ([string]::IsNullOrWhiteSpace($dirListing)) { $dirListing = "<none>" }
+    throw "Export failed: expected executable '$gameExePath' was not created. Output directory files: $dirListing"
 }
 
 Write-Host "Export complete."


### PR DESCRIPTION
## Summary
- make `tools/ci/export-windows.ps1` resolve Godot CLI robustly (`GODOT4`, `GODOT`, `godot`, `godot4`) and fail with clearer diagnostics
- update workflow runtime wiring (`actions/checkout@v5`, Node 24 env opt-in, and explicit Godot CLI verification step)
- update lobby friend list to invite any online friend instead of filtering by current app ID

## Test plan
- [x] run lint checks for edited files
- [ ] run workflow dispatch and verify export step succeeds with resolved Godot CLI
- [ ] verify lobby now lists all online friends and invite works from lobby UI