### PR TITLE
Add strategy-game reference docs and persistent rule

### DIFF
--- a/.cursor/rules/strategy-game-doc-reference.mdc
+++ b/.cursor/rules/strategy-game-doc-reference.mdc
@@ -1,0 +1,20 @@
+---
+description: Use strategy-game docs as source of truth for strategy mode updates
+alwaysApply: true
+---
+
+# Strategy Mode Doc Reference
+
+When making changes to strategy mode systems (including `strategy_game`, strategy scene files, terrain editing, or strategy mode routing), use `docs/strategy-game` as the primary reference set.
+
+## Required References
+
+- `docs/strategy-game/REQ_00_reference_index.md`
+- `docs/strategy-game/REQ_01_vision_and_architecture.md`
+- `docs/strategy-game/REQ_02_systems_and_data_contracts.md`
+
+## Update Expectations
+
+1. Keep implementation aligned with these strategy docs.
+2. If behavior/contracts change, update the corresponding strategy doc in the same PR.
+3. Preserve host-authoritative assumptions for multiplayer state mutation unless explicitly changed.

--- a/docs/strategy-game/REQ_00_reference_index.md
+++ b/docs/strategy-game/REQ_00_reference_index.md
@@ -1,0 +1,23 @@
+# Strategy Game Reference Index
+
+This document set is the canonical reference for the `strategy_game` mode.
+
+Use these docs as the source of truth when updating:
+
+- `res://scripts/strategy_game.gd`
+- `res://scenes/game/strategy/strategy_game.tscn`
+- strategy support systems (terrain editing/registry, mode routing, strategy HUD)
+
+## Reference Documents
+
+1. `REQ_01_vision_and_architecture.md`
+2. `REQ_02_systems_and_data_contracts.md`
+
+## Update Rule
+
+When behavior changes in the strategy mode:
+
+1. Update the relevant strategy doc first (or in the same change).
+2. Keep naming aligned between docs and runtime symbols.
+3. Document new exported vars, signals, and data contracts.
+4. Call out multiplayer assumptions explicitly.

--- a/docs/strategy-game/REQ_01_vision_and_architecture.md
+++ b/docs/strategy-game/REQ_01_vision_and_architecture.md
@@ -1,0 +1,43 @@
+# Strategy Game: Vision and Architecture
+
+## Purpose
+
+The strategy mode provides a hex-based command layer focused on territory, terrain, and tactical planning.
+
+## Player Fantasy
+
+- Command the map from a strategic perspective.
+- Shape terrain to create defensive and offensive advantages.
+- Make deliberate positional decisions over twitch execution.
+
+## Core Mode Goals
+
+- Readable hex map state at all times.
+- Fast edit/inspect loop for terrain and cells.
+- Deterministic state updates suitable for multiplayer authority.
+
+## Mode Boundaries
+
+The strategy mode owns:
+
+- Hex map state and terrain typing.
+- Strategy-mode UI and map interaction flow.
+- Mode-specific scene and script behavior.
+
+The strategy mode does not own:
+
+- Cross-mode bootstrap and phase transitions (owned by autoload managers).
+- Non-strategy scene logic.
+
+## Primary Runtime Surfaces
+
+- Scene: `res://scenes/game/strategy/strategy_game.tscn`
+- Script: `res://scripts/strategy_game.gd`
+- Related UI tooling: `res://scripts/ui/terrain_creator.gd`
+- Terrain registry: `res://scripts/autoload/terrain_definitions.gd`
+
+## Integration Notes
+
+- Multiplayer should remain host-authoritative for map state mutation.
+- Any client-facing edit operation should route through authoritative state application.
+- New strategy systems should define explicit data contracts (ids, terrain keys, event payloads).

--- a/docs/strategy-game/REQ_02_systems_and_data_contracts.md
+++ b/docs/strategy-game/REQ_02_systems_and_data_contracts.md
@@ -1,0 +1,51 @@
+# Strategy Game: Systems and Data Contracts
+
+## Systems Overview
+
+### 1) Hex Grid State
+
+Tracks per-cell terrain and derived map semantics.
+
+Expected contract:
+
+- Stable coordinate keying per hex cell.
+- Deterministic terrain lookup and mutation.
+- Clear defaults for unassigned cells.
+
+### 2) Terrain Editing Surface
+
+Provides map editing controls for selecting cells and applying terrain types.
+
+Expected contract:
+
+- UI selection state is decoupled from authoritative map state.
+- Terrain id chosen in UI maps to a valid terrain definition key.
+- Invalid terrain ids are rejected safely.
+
+### 3) Terrain Definitions Registry
+
+Central source of available terrain ids and presentation metadata.
+
+Expected contract:
+
+- Terrain ids are unique and stable.
+- Runtime consumers can enumerate terrain definitions.
+- Registry emits update notifications when definitions change.
+
+## Data Contract Requirements
+
+When changing strategy data structures, document:
+
+- Key names and value types.
+- Ownership (local UI cache vs authoritative state).
+- Default/fallback behavior.
+- Serialization expectations for save/network transport.
+
+## Change Checklist
+
+For any strategy-system update:
+
+1. Confirm docs match new runtime symbols and payloads.
+2. Verify mode routing still points to strategy scene.
+3. Validate terrain edit flow from UI selection to map application.
+4. Re-check multiplayer behavior for host/client state authority.


### PR DESCRIPTION
## Summary
- add a dedicated `docs/strategy-game` reference set for strategy mode architecture and data contracts
- add a persistent Cursor rule that points strategy mode updates to the new docs set
- establish a clear doc-first update expectation for `strategy_game`-related changes

## Test plan
- [x] verify new docs are present under `docs/strategy-game`
- [x] verify new rule exists at `.cursor/rules/strategy-game-doc-reference.mdc`
- [ ] apply the docs/rule in the next strategy gameplay update PR