### PR TITLE
fix(ci): use standard Godot build, fix silent export failure

### DIFF
--- a/.github/workflows/steam-playtest.yml
+++ b/.github/workflows/steam-playtest.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           version: ${{ env.GODOT_VERSION }}
           include-templates: true
+          use-dotnet: false
 
       - name: Verify Godot CLI
         shell: pwsh

--- a/tools/ci/export-windows.ps1
+++ b/tools/ci/export-windows.ps1
@@ -18,12 +18,18 @@ function Resolve-GodotCommand {
 
     foreach ($candidate in $candidates) {
         if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
-        if (Test-Path $candidate) { return $candidate }
-        $command = Get-Command $candidate -ErrorAction SilentlyContinue
-        if ($null -ne $command) { return $command.Path }
+        # Use Get-Command first — it handles PATH lookup, PATHEXT extension resolution,
+        # and correctly resolves hard links / symlinks to their actual executable path.
+        $cmd = Get-Command $candidate -ErrorAction SilentlyContinue
+        if ($null -ne $cmd) { return $cmd.Source }
+        # Fallback: try path directly and with .exe suffix for absolute paths
+        if ($candidate -match '[/\\]') {
+            if (Test-Path "$candidate.exe") { return "$candidate.exe" }
+            if (Test-Path $candidate) { return $candidate }
+        }
     }
 
-    throw "Godot CLI not found. Checked env:GODOT4, env:GODOT, godot, and godot4."
+    throw "Godot CLI not found. Checked env:GODOT4, env:GODOT, godot4, and godot."
 }
 
 $projectRootResolved = (Resolve-Path $ProjectRoot).Path
@@ -39,31 +45,13 @@ Copy-Item -Path $presetTemplatePath -Destination $presetPath -Force
 New-Item -ItemType Directory -Path $outputDirResolved -Force | Out-Null
 
 $gameExePath = Join-Path $outputDirResolved "FireTeamMNG.exe"
-# Godot export is most reliable with a path relative to project root.
-$relativeExportPath = ((Join-Path $OutputDir "FireTeamMNG.exe") -replace "\\", "/").TrimStart("./")
 $godotCommand = Resolve-GodotCommand
 
 Write-Host "Exporting with preset '$ExportPresetName' to '$gameExePath'..."
 Write-Host "Using Godot CLI: $godotCommand"
-$exportOutput = @()
-$exitCode = $null
-try {
-    $exportOutput = & $godotCommand --headless --verbose --path $projectRootResolved --export-release $ExportPresetName $relativeExportPath 2>&1
-    $exitCode = $LASTEXITCODE
-} catch {
-    $exportOutput += $_.Exception.Message
-    $exitCode = $LASTEXITCODE
-}
-
-if ($exportOutput.Count -gt 0) {
-    Write-Host "Godot export output:"
-    $exportOutput | ForEach-Object { Write-Host $_ }
-}
-
-if ($null -eq $exitCode) {
-    # Some command invocation failures do not populate LASTEXITCODE.
-    $exitCode = if ($?) { 0 } else { 1 }
-}
+# Stream Godot output directly to the log (no capture) so every line is visible in CI.
+& $godotCommand --headless --verbose --path $projectRootResolved --export-release $ExportPresetName $gameExePath
+$exitCode = $LASTEXITCODE
 
 if ($exitCode -ne 0) {
     throw "Godot export command failed with exit code $exitCode."


### PR DESCRIPTION
## Root Cause Analysis

The CI export was silently failing with zero output in ~600ms (real Godot exports take 10-30s). Two issues found:

### 1. Mono build causes silent startup failure (primary fix)
chickensoft-games/setup-godot@v2 defaults to use-dotnet: true, which downloads Godot_v4.6.1-stable_mono_win64. On Windows, the action creates a **hard link** named \godot\ (no \.exe\ extension) in the bin dir.

When called by full path (\C:\Users\runneradmin\bin\godot\), the Mono build fails to initialize its .NET runtime silently and exits with code 0 — no output, no file created.

This project is **GDScript-only** — the Mono build is unnecessary overhead. Setting \use-dotnet: false\ uses \Godot_v4.6.1-stable_win64\ instead, which has no .NET requirements.

### 2. Output capture hid all diagnostic information
Capturing Godot output with \2>&1\ and printing it after the fact meant CI logs showed nothing useful on failure. Streaming directly to the log is better practice for CI.

## Changes
- **steam-playtest.yml**: add use-dotnet: false to setup-godot step
- **export-windows.ps1**: stream Godot output directly (no 2>&1 capture)
- **export-windows.ps1**: Resolve-GodotCommand uses Get-Command first (handles PATHEXT/hard link resolution correctly) before falling back to Test-Path
- **export-windows.ps1**: pass absolute $gameExePath to --export-release (simpler and unambiguous)

Co-Authored-By: Oz <oz-agent@warp.dev>