### PR TITLE
Ignore local Windows export artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,11 @@ desktop.ini
 *.swp
 /demo
 /addons
+
+# Local Windows export artifacts at repo root
+/FireTeam MNG.exe
+/FireTeam MNG.console.exe
+/FireTeam MNG.pck
+/steam_api64.dll
+/libgodotsteam.windows.*.dll
+/liblimboai.windows.*.dll


### PR DESCRIPTION
## Summary
- add root-level `.gitignore` patterns for local Windows export binaries and DLL artifacts
- keep repository status clean during local export/test cycles
- avoid accidental commit noise from generated build outputs

## Test plan
- [x] verify generated local export files no longer appear as untracked
- [ ] run local export once and confirm only intended source changes appear in git status