### PR TITLE
fix(ci): use dedicated Steam builder credentials

### DIFF
--- a/.github/workflows/steam-playtest.yml
+++ b/.github/workflows/steam-playtest.yml
@@ -19,8 +19,8 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       STEAM_APP_ID: ${{ secrets.STEAM_APP_ID }}
       STEAM_DEPOT_ID_WINDOWS: ${{ secrets.STEAM_DEPOT_ID_WINDOWS }}
-      STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
-      STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
+      STEAM_USERNAME: ${{ secrets.STEAM_BUILDER_USERNAME }}
+      STEAM_PASSWORD: ${{ secrets.STEAM_BUILDER_PASSWORD }}
       STEAM_CONFIG_VDF: ${{ secrets.STEAM_CONFIG_VDF }}
 
     steps:


### PR DESCRIPTION
## Summary
- Update steam playtest workflow to use the dedicated builder account secret names.
- Keep existing STEAM_CONFIG_VDF auth path unchanged while aligning username/password inputs.

## Test plan
- [ ] Trigger steam-playtest workflow and verify login step authenticates.
- [ ] Confirm depot upload uses expected builder account.

Made with [Cursor](https://cursor.com)