### PR TITLE
fix(ci): run SteamCMD self-update before restoring session cache

### DIFF
--- a/tools/ci/upload-steam.ps1
+++ b/tools/ci/upload-steam.ps1
@@ -41,6 +41,10 @@ if (-not (Test-Path $steamExe)) {
     Expand-Archive -Path $steamZip -DestinationPath $steamDir -Force
 }
 
+# Run SteamCMD once to let it self-update before writing config.
+Write-Host "Running SteamCMD self-update..."
+& $steamExe +quit
+
 # Restore cached Steam session so no interactive Steam Guard prompt is needed.
 if (-not [string]::IsNullOrWhiteSpace($steamConfigVdf)) {
     $steamConfigDir = Join-Path $steamDir "config"


### PR DESCRIPTION
## Summary
- Run SteamCMD once with +quit immediately after extraction so it can self-update before config restoration.
- Improve reliability of cached Steam session restore in CI by ensuring SteamCMD initialization has completed.

## Test plan
- [ ] Execute CI Steam upload workflow and confirm no interactive Steam Guard prompt.
- [ ] Verify upload step still succeeds with cached config.vdf.

Made with [Cursor](https://cursor.com)