### PR TITLE
fix(ci): add manual Steam Guard input and disable push trigger

### DIFF
--- a/.github/workflows/steam-playtest.yml
+++ b/.github/workflows/steam-playtest.yml
@@ -1,10 +1,16 @@
 name: Build And Upload Steam Playtest
 
 on:
-  push:
-    branches:
-      - main
+  # TODO: re-enable push trigger once STEAM_TOTP_SECRET is configured
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
+    inputs:
+      steam_guard_code:
+        description: "Steam Guard code from mobile app (only needed until STEAM_TOTP_SECRET is configured)"
+        required: false
+        type: string
 
 jobs:
   export-and-upload:
@@ -22,6 +28,7 @@ jobs:
       STEAM_USERNAME: ${{ secrets.STEAM_BUILDER_USERNAME }}
       STEAM_PASSWORD: ${{ secrets.STEAM_BUILDER_PASSWORD }}
       STEAM_TOTP_SECRET: ${{ secrets.STEAM_TOTP_SECRET }}
+      STEAM_GUARD_CODE: ${{ inputs.steam_guard_code }}
 
     steps:
       - name: Checkout

--- a/tools/ci/upload-steam.ps1
+++ b/tools/ci/upload-steam.ps1
@@ -28,7 +28,8 @@ $steamAppId = Require-Env "STEAM_APP_ID"
 $steamDepotIdWindows = Require-Env "STEAM_DEPOT_ID_WINDOWS"
 $steamUser = Require-Env "STEAM_USERNAME"
 $steamPassword = Require-Env "STEAM_PASSWORD"
-$steamTotpSecret = Require-Env "STEAM_TOTP_SECRET"
+$steamTotpSecret = [Environment]::GetEnvironmentVariable("STEAM_TOTP_SECRET")
+$steamGuardCode = [Environment]::GetEnvironmentVariable("STEAM_GUARD_CODE")
 
 $steamDir = Join-Path $env:RUNNER_TEMP "steamcmd"
 New-Item -ItemType Directory -Path $steamDir -Force | Out-Null
@@ -78,8 +79,16 @@ function Get-SteamGuardCode {
 Write-Host "Running SteamCMD self-update..."
 & $steamExe +quit
 
-$guardCode = Get-SteamGuardCode -SharedSecret $steamTotpSecret
-Write-Host "Generated Steam Guard TOTP code."
+# Resolve Steam Guard code: prefer manual code (workflow_dispatch), then TOTP secret
+if (-not [string]::IsNullOrWhiteSpace($steamGuardCode)) {
+    $guardCode = $steamGuardCode
+    Write-Host "Using manually provided Steam Guard code."
+} elseif (-not [string]::IsNullOrWhiteSpace($steamTotpSecret)) {
+    $guardCode = Get-SteamGuardCode -SharedSecret $steamTotpSecret
+    Write-Host "Generated Steam Guard code from TOTP secret."
+} else {
+    throw "No Steam Guard code available. Provide a code via workflow_dispatch or set STEAM_TOTP_SECRET."
+}
 
 $templateAppBuild = Join-Path $projectRootResolved "tools/steam/app_build_template.vdf"
 $templateDepotBuild = Join-Path $projectRootResolved "tools/steam/depot_build_windows_template.vdf"


### PR DESCRIPTION
Fixes #104

- Adds a workflow_dispatch input field for the Steam Guard code from the mobile app
- Prefers manual code over TOTP when provided
- Makes both auth methods optional (one must be set)
- Disables push trigger temporarily — use Run Workflow manually until STEAM_TOTP_SECRET is configured

Co-Authored-By: Oz <oz-agent@warp.dev>