### PR TITLE
fix(ci): warm SteamCMD auth before upload step

### DIFF
--- a/.github/workflows/steam-upload.yml
+++ b/.github/workflows/steam-upload.yml
@@ -33,6 +33,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Warm SteamCMD and validate auth
+        shell: pwsh
+        run: |
+          ./tools/ci/upload-steam.ps1 `
+            -ProjectRoot "$PWD" `
+            -PrepareOnly
+
       - name: Download latest build artifact
         shell: pwsh
         run: |
@@ -51,4 +58,5 @@ jobs:
           ./tools/ci/upload-steam.ps1 `
             -ProjectRoot "$PWD" `
             -BuildOutputDir "build/windows" `
-            -SteamBranch "${env:STEAM_BRANCH}"
+            -SteamBranch "${env:STEAM_BRANCH}" `
+            -SkipSteamCmdUpdate

--- a/tools/ci/upload-steam.ps1
+++ b/tools/ci/upload-steam.ps1
@@ -4,7 +4,11 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$BuildOutputDir = "build/windows",
     [Parameter(Mandatory = $false)]
-    [string]$SteamBranch = "playtest"
+    [string]$SteamBranch = "playtest",
+    [Parameter(Mandatory = $false)]
+    [switch]$PrepareOnly,
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipSteamCmdUpdate
 )
 
 $ErrorActionPreference = "Stop"
@@ -20,7 +24,7 @@ function Require-Env {
 
 $projectRootResolved = (Resolve-Path $ProjectRoot).Path
 $contentRoot = Join-Path $projectRootResolved $BuildOutputDir
-if (-not (Test-Path $contentRoot)) {
+if (-not $PrepareOnly -and -not (Test-Path $contentRoot)) {
     throw "Build output directory not found: '$contentRoot'"
 }
 
@@ -75,9 +79,13 @@ function Get-SteamGuardCode {
     return $guardCode
 }
 
-# Run SteamCMD once to let it self-update.
-Write-Host "Running SteamCMD self-update..."
-& $steamExe +quit
+if ($SkipSteamCmdUpdate) {
+    Write-Host "Skipping SteamCMD self-update."
+} else {
+    # Run SteamCMD once to let it self-update.
+    Write-Host "Running SteamCMD self-update..."
+    & $steamExe +quit
+}
 
 # Resolve Steam Guard code: prefer manual code (workflow_dispatch), then TOTP secret
 if (-not [string]::IsNullOrWhiteSpace($steamGuardCode)) {
@@ -88,6 +96,18 @@ if (-not [string]::IsNullOrWhiteSpace($steamGuardCode)) {
     Write-Host "Generated Steam Guard code from TOTP secret."
 } else {
     throw "No Steam Guard code available. Provide a code via workflow_dispatch or set STEAM_TOTP_SECRET."
+}
+
+if ($PrepareOnly) {
+    Write-Host "Validating Steam credentials and guard code..."
+    & $steamExe +set_steam_guard_code $guardCode +login $steamUser $steamPassword +quit
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "SteamCMD auth validation failed with exit code $LASTEXITCODE"
+    }
+
+    Write-Host "Steam authentication is ready."
+    return
 }
 
 $templateAppBuild = Join-Path $projectRootResolved "tools/steam/app_build_template.vdf"


### PR DESCRIPTION
## Summary
- Add an early SteamCMD warmup/auth validation phase to the upload workflow.
- Skip SteamCMD self-update during the final upload step so upload starts immediately.

## Test plan
- [ ] Run Upload to Steam workflow and confirm warmup step succeeds.
- [ ] Verify Upload to Steam step starts without self-update delay.
- [ ] Validate successful upload to target Steam branch.

Made with [Cursor](https://cursor.com)