### PR TITLE
fix(ci): simplify steam upload by removing PrepareOnly and warm step

### DIFF
--- a/.github/workflows/steam-upload.yml
+++ b/.github/workflows/steam-upload.yml
@@ -33,13 +33,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Warm SteamCMD and validate auth
-        shell: pwsh
-        run: |
-          ./tools/ci/upload-steam.ps1 `
-            -ProjectRoot "$PWD" `
-            -PrepareOnly
-
       - name: Download latest build artifact
         shell: pwsh
         run: |
@@ -58,5 +51,4 @@ jobs:
           ./tools/ci/upload-steam.ps1 `
             -ProjectRoot "$PWD" `
             -BuildOutputDir "build/windows" `
-            -SteamBranch "${env:STEAM_BRANCH}" `
-            -SkipSteamCmdUpdate
+            -SteamBranch "${env:STEAM_BRANCH}"

--- a/tools/ci/upload-steam.ps1
+++ b/tools/ci/upload-steam.ps1
@@ -4,11 +4,7 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$BuildOutputDir = "build/windows",
     [Parameter(Mandatory = $false)]
-    [string]$SteamBranch = "playtest",
-    [Parameter(Mandatory = $false)]
-    [switch]$PrepareOnly,
-    [Parameter(Mandatory = $false)]
-    [switch]$SkipSteamCmdUpdate
+    [string]$SteamBranch = "playtest"
 )
 
 $ErrorActionPreference = "Stop"
@@ -24,7 +20,7 @@ function Require-Env {
 
 $projectRootResolved = (Resolve-Path $ProjectRoot).Path
 $contentRoot = Join-Path $projectRootResolved $BuildOutputDir
-if (-not $PrepareOnly -and -not (Test-Path $contentRoot)) {
+if (-not (Test-Path $contentRoot)) {
     throw "Build output directory not found: '$contentRoot'"
 }
 
@@ -79,13 +75,9 @@ function Get-SteamGuardCode {
     return $guardCode
 }
 
-if ($SkipSteamCmdUpdate) {
-    Write-Host "Skipping SteamCMD self-update."
-} else {
-    # Run SteamCMD once to let it self-update.
-    Write-Host "Running SteamCMD self-update..."
-    & $steamExe +quit
-}
+# Run SteamCMD once to let it self-update.
+Write-Host "Running SteamCMD self-update..."
+& $steamExe +quit
 
 # Resolve Steam Guard code: prefer manual code (workflow_dispatch), then TOTP secret
 if (-not [string]::IsNullOrWhiteSpace($steamGuardCode)) {
@@ -98,19 +90,7 @@ if (-not [string]::IsNullOrWhiteSpace($steamGuardCode)) {
     throw "No Steam Guard code available. Provide a code via workflow_dispatch or set STEAM_TOTP_SECRET."
 }
 
-if ($PrepareOnly) {
-    Write-Host "Validating Steam credentials and guard code..."
-    & $steamExe +set_steam_guard_code $guardCode +login $steamUser $steamPassword +quit
-
-    if ($LASTEXITCODE -ne 0) {
-        throw "SteamCMD auth validation failed with exit code $LASTEXITCODE"
-    }
-
-    Write-Host "Steam authentication is ready."
-    return
-}
-
-$templateAppBuild = Join-Path $projectRootResolved "tools/steam/app_build_template.vdf"
+$templateAppBuild
 $templateDepotBuild = Join-Path $projectRootResolved "tools/steam/depot_build_windows_template.vdf"
 if (-not (Test-Path $templateAppBuild)) { throw "Missing $templateAppBuild" }
 if (-not (Test-Path $templateDepotBuild)) { throw "Missing $templateDepotBuild" }


### PR DESCRIPTION
Remove PrepareOnly switch, SkipSteamCmdUpdate switch, and the separate warm auth step from the upload workflow. SteamCMD self-update now always runs before the upload.

Changes:
- Removed -PrepareOnly and -SkipSteamCmdUpdate params from upload-steam.ps1
- Removed the 'Warm SteamCMD and validate auth' step from steam-upload.yml
- SteamCMD self-update always runs (no skip option)
- Simplified content root check (no PrepareOnly bypass)

Co-Authored-By: Oz <oz-agent@warp.dev>